### PR TITLE
Add self-monitoring and 2-bit quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Indiana-C
 
-Indiana-C is a minimal reasoning engine built to stand alone on the CPU. It keeps the deliberate `<think>`-style reflection and step-by-step planning introduced by the original R1 engine while removing every dependency on external hosting platforms.
+Indiana-C is a minimal reasoning engine built to stand alone on the CPU. It keeps the deliberate `<think>`-style reflection and step-by-step planning introduced by the open-source DEEPSEEK R1 engine while removing every dependency on external hosting platforms.
+
+The project borrows the R1 core as its reasoning heart. DEEPSEEK released an autonomous chain-of-thought stack, and Indiana-C reuses that public skeleton so CPU deployments still enjoy explicit traces and self-verifying steps without cloud services.
+
+On top of the borrowed core, Indiana-C layers a self-monitoring memory inspired by previous experiments like SUPPERTIME and D2C. Each run snapshots the entire codebase and logs prompts and outputs into an embedded database so the system can study and fine-tune itself offline.
 
 Inspired by Andrej Karpathy's [nanoGPT](https://github.com/karpathy/nanoGPT), the core is tiny and readable. Indiana-C is not a fork but a fresh kernel, free from old tensors and designed for autonomy.
 

--- a/indiana_c/__init__.py
+++ b/indiana_c/__init__.py
@@ -1,4 +1,12 @@
 from .generation import generate_text
 from .model import IndianaC, IndianaCConfig
+from .monitor import SelfMonitor
+from .quantize import quantize_2bit
 
-__all__ = ["IndianaC", "IndianaCConfig", "generate_text"]
+__all__ = [
+    "IndianaC",
+    "IndianaCConfig",
+    "generate_text",
+    "quantize_2bit",
+    "SelfMonitor",
+]

--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -1,6 +1,8 @@
 import torch
 
 from .model import IndianaC, IndianaCConfig
+from .monitor import SelfMonitor
+from .quantize import quantize_2bit
 
 
 def encode(text: str, vocab_size: int) -> torch.Tensor:
@@ -18,7 +20,11 @@ def generate_text(
 ) -> str:
     config = config or IndianaCConfig()
     model = IndianaC(config)
+    quantize_2bit(model)
+    monitor = SelfMonitor()
     model.eval()
     idx = encode(prompt, config.vocab_size)
     out = model.generate(idx, max_new_tokens=max_new_tokens)
-    return decode(out[0])
+    text = decode(out[0])
+    monitor.log(prompt, text)
+    return text

--- a/indiana_c/monitor.py
+++ b/indiana_c/monitor.py
@@ -1,0 +1,61 @@
+"""Self-monitoring utilities for Indiana-C.
+
+The monitor snapshot the entire repository and logs prompts and
+responses for further fine-tuning. All files are stored inside an
+SQLite database so the system can reflect on its own source and data.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import time
+from pathlib import Path
+
+
+class SelfMonitor:
+    """Record code snapshots and generation events."""
+
+    def __init__(self, db_path: str = "indiana_memory.sqlite"):
+        self.conn = sqlite3.connect(db_path)
+        self._init_db()
+        self.snapshot_codebase()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS files(path TEXT PRIMARY KEY, content BLOB, sha256 TEXT)"
+        )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS logs(ts REAL, prompt TEXT, output TEXT)"
+        )
+        self.conn.commit()
+
+    def snapshot_codebase(self, root: str | Path = ".") -> None:
+        """Store all files in the repository with their hashes."""
+        root_path = Path(root)
+        for path in root_path.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.name == "indiana_memory.sqlite":
+                continue
+            data = path.read_bytes()
+            sha = hashlib.sha256(data).hexdigest()
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT OR REPLACE INTO files(path, content, sha256) VALUES (?,?,?)",
+                (str(path), sqlite3.Binary(data), sha),
+            )
+        self.conn.commit()
+
+    def log(self, prompt: str, output: str) -> None:
+        """Log a generation event with timestamp."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO logs(ts, prompt, output) VALUES (?,?,?)",
+            (time.time(), prompt, output),
+        )
+        self.conn.commit()
+
+
+__all__ = ["SelfMonitor"]

--- a/indiana_c/quantize.py
+++ b/indiana_c/quantize.py
@@ -1,0 +1,30 @@
+"""2-bit weight quantization for Indiana-C.
+
+The quantization squeezes model parameters to four discrete levels so
+that the model fits on very small devices while keeping the reasoning
+chain intact.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+@torch.no_grad()
+def quantize_2bit(model: nn.Module) -> None:
+    """Quantize the model weights to 2-bit precision in-place."""
+    for param in model.parameters():
+        if param.dtype not in (torch.float32, torch.float64):
+            continue
+        max_val = param.abs().max()
+        if max_val == 0:
+            continue
+        scale = max_val / 3
+        q = (param / scale).round().clamp(-3, 3)
+        signs = torch.sign(q)
+        mags = torch.where(q.abs() > 2, torch.tensor(3.0, device=param.device), torch.tensor(1.0, device=param.device))
+        param.copy_(signs * mags * scale)
+
+
+__all__ = ["quantize_2bit"]


### PR DESCRIPTION
## Summary
- Clarify README: engine derives from open-source DEEPSEEK R1 and now sports an embedded self-monitoring memory
- Add SQLite-based self-monitor that snapshots all repository files and logs prompt/output pairs
- Introduce 2-bit weight quantization utilities and integrate them into text generation

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(ProxyError: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_688e2c6d2c848329a8be32a1a09b78e8