### PR TITLE
Add think-aware generation and CLI option

### DIFF
--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from .generation import generate_text
+from .generation import generate_with_think
 from .model import IndianaCConfig
 
 
@@ -8,11 +8,19 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Indiana-C text generation")
     parser.add_argument("prompt", nargs="?", help="prompt to complete")
     parser.add_argument("--max-new-tokens", type=int, default=50)
+    parser.add_argument("--show-thoughts", action="store_true", help="display thoughts before final answer")
     args = parser.parse_args()
 
     config = IndianaCConfig(vocab_size=256)
-    text = generate_text(args.prompt, max_new_tokens=args.max_new_tokens, config=config)
-    print(text)
+    thoughts, final = generate_with_think(
+        args.prompt, max_new_tokens=args.max_new_tokens, config=config
+    )
+    if args.show_thoughts:
+        if thoughts:
+            print(thoughts)
+        print(final)
+    else:
+        print(final)
 
 
 if __name__ == "__main__":

--- a/tests/test_indiana_c.py
+++ b/tests/test_indiana_c.py
@@ -1,6 +1,8 @@
 import torch
 
 from indiana_c import IndianaC, IndianaCConfig
+from indiana_c.generation import generate_with_think
+from unittest.mock import patch
 
 
 def test_forward():
@@ -22,3 +24,32 @@ def test_generate():
     idx = torch.randint(0, config.vocab_size, (1, 4))
     out = model.generate(idx, max_new_tokens=2)
     assert out.shape[-1] == 6
+
+
+def test_generate_with_think_parses_sections():
+    config = IndianaCConfig(vocab_size=256)
+
+    class DummyModel:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def eval(self):
+            pass
+
+        def generate(self, idx, max_new_tokens):
+            addition = torch.tensor(
+                [[ord(c) % self.cfg.vocab_size for c in "abc</think>answer"]],
+                dtype=torch.long,
+            )
+            return torch.cat((idx, addition), dim=1)
+
+    class DummyMonitor:
+        def log(self, prompt, text):
+            pass
+
+    with patch("indiana_c.generation.IndianaC", DummyModel), patch(
+        "indiana_c.generation.SelfMonitor", lambda: DummyMonitor()
+    ), patch("indiana_c.generation.quantize_2bit", lambda model: None):
+        thoughts, final = generate_with_think("Q", max_new_tokens=20, config=config)
+    assert thoughts == "abc"
+    assert final == "answer"


### PR DESCRIPTION
## Summary
- introduce `generate_with_think` to capture internal thoughts and final answer
- add `--show-thoughts` CLI flag for optional thought display
- test parsing of `<think>` sections and final answer

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e498fb6e48329a503bc43117b11a5