### PR TITLE
feat: add prompt search

### DIFF
--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -30,12 +30,19 @@ def generate_text(
     config: IndianaCConfig | None = None,
     *,
     log_reasoning: bool = False,
+    use_history: bool = False,
+    history_limit: int = 3,
 ) -> str | tuple[str, dict[str, float | int]]:
     prompt = prompt or CORE_PROMPT
     config = config or IndianaCConfig()
+    monitor = SelfMonitor()
+    if use_history:
+        history = monitor.search_prompts(prompt, limit=history_limit)
+        if history:
+            combined = "\n".join(p for p, _ in history)
+            prompt = f"{combined}\n{prompt}"
     model = IndianaC(config)
     quantize_2bit(model)
-    monitor = SelfMonitor()
     model.eval()
     idx = encode(prompt, config.vocab_size)
     out = model.generate(idx, max_new_tokens=max_new_tokens)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,16 @@
+import os
+
+from indiana_c.monitor import SelfMonitor
+
+
+def test_search_prompts(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
+        monitor.log("hello world", "out1")
+        monitor.log("another message", "out2")
+        results = monitor.search_prompts("hello")
+        assert ("hello world", "out1") in results
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- index prompts using SQLite FTS5 and allow searching
- optionally augment prompt with similar history during generation
- add tests for prompt search

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_688e4b729a408329b887dc9c643ce361