### PR TITLE
Add reasoning tests and enable metadata

### DIFF
--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -64,14 +64,16 @@ def generate_with_think(
     """Generate text while allowing a hook for reasoning steps.
 
     Currently this is a light wrapper around :func:`generate_text` so that it can
-    be mocked in tests and extended in the future.
+    be mocked in tests and extended in the future. The function requests
+    reasoning metadata from :func:`generate_text` and therefore returns a tuple
+    of the generated text and the associated statistics.
     """
 
     return generate_text(
         prompt,
         max_new_tokens=max_new_tokens,
         config=config,
-        log_reasoning=False,
+        log_reasoning=True,
     )
 
 

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,35 @@
+"""Tests for reasoning-related generation helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from indiana_c.generation import generate_consistent_text, generate_with_think
+
+
+def test_generate_with_think_returns_thought_and_final() -> None:
+    """Ensure ``generate_with_think`` yields both text and metadata."""
+
+    with patch("indiana_c.generation.generate_text", return_value=("thought", {"c": 1})) as mock_gen:
+        result = generate_with_think("prompt")
+
+    # The wrapper should request reasoning metadata and return the tuple as-is
+    assert result == ("thought", {"c": 1})
+    mock_gen.assert_called_once_with("prompt", max_new_tokens=50, config=None, log_reasoning=True)
+
+
+def test_consistency_improves_with_multiple_attempts() -> None:
+    """Using ``n>1`` should select the most frequent answer."""
+
+    side_effect = ["B", "A", "A"]
+
+    # Single attempt may yield an inconsistent answer
+    with patch("indiana_c.generation.generate_with_think", side_effect=side_effect):
+        single = generate_consistent_text("prompt", n=1)
+
+    # Multiple attempts should recover the majority answer "A"
+    with patch("indiana_c.generation.generate_with_think", side_effect=side_effect):
+        multi = generate_consistent_text("prompt", n=3)
+
+    assert single != "A"
+    assert multi == "A"


### PR DESCRIPTION
## Summary
- ensure `generate_with_think` requests reasoning metadata
- add reasoning tests for thought output and consistency

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4d8648d88329a0c11138566ce20e