### PR TITLE
Add sampling controls and CLI options

### DIFF
--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -15,6 +15,9 @@ def main() -> None:
         default=1,
         help="number of attempts to ensure answer consistency",
     )
+    parser.add_argument("--temperature", type=float, default=1.0, help="sampling temperature")
+    parser.add_argument("--top-k", type=int, default=None, help="top-k filtering")
+    parser.add_argument("--top-p", type=float, default=None, help="nucleus top-p sampling")
     args = parser.parse_args()
 
     config = IndianaCConfig(vocab_size=256)
@@ -24,6 +27,9 @@ def main() -> None:
             n=args.consistency,
             max_new_tokens=args.max_new_tokens,
             config=config,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
         )
         print(result)
     else:
@@ -32,6 +38,9 @@ def main() -> None:
             max_new_tokens=args.max_new_tokens,
             config=config,
             log_reasoning=args.verbose,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
         )
         if args.verbose:
             text, meta = result

--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -24,6 +24,9 @@ def generate_text(
     log_reasoning: bool = False,
     use_history: bool = False,
     history_limit: int = 3,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    top_p: float | None = None,
 ) -> str | tuple[str, dict[str, float | int]]:
     prompt = prompt or CORE_PROMPT
     config = config or IndianaCConfig()
@@ -37,7 +40,13 @@ def generate_text(
     quantize_2bit(model)
     model.eval()
     idx = tokenizer.encode(prompt)
-    out = model.generate(idx, max_new_tokens=max_new_tokens)
+    out = model.generate(
+        idx,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+    )
     text = tokenizer.decode(out[0])
     monitor.log(prompt, text)
     complexity, entropy = estimate_complexity_and_entropy(text)
@@ -51,6 +60,10 @@ def generate_with_think(
     prompt: str | None = None,
     max_new_tokens: int = 50,
     config: IndianaCConfig | None = None,
+    *,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    top_p: float | None = None,
 ) -> str | tuple[str, dict[str, float | int]]:
     """Generate text while allowing a hook for reasoning steps.
 
@@ -63,6 +76,9 @@ def generate_with_think(
         max_new_tokens=max_new_tokens,
         config=config,
         log_reasoning=False,
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
     )
 
 

--- a/tests/test_indiana_c.py
+++ b/tests/test_indiana_c.py
@@ -1,3 +1,5 @@
+import torch
+
 from indiana_c import IndianaC, IndianaCConfig
 from indiana_c.tokenizer import tokenizer
 
@@ -17,3 +19,20 @@ def test_generate():
     idx = tokenizer.encode("hello")
     out = model.generate(idx, max_new_tokens=2)
     assert out.shape[-1] == idx.shape[1] + 2
+
+
+def test_generate_top_k_top_p():
+    config = IndianaCConfig(block_size=16, n_layer=2, n_head=2, n_embd=32, vocab_size=3)
+    model = IndianaC(config)
+
+    def fake_forward(self, idx: torch.Tensor, targets: torch.Tensor | None = None):
+        B, T = idx.shape
+        logits = torch.tensor([1.0, 0.5, 0.1]).repeat(B, T, 1)
+        return logits, None
+
+    model.forward = fake_forward.__get__(model, IndianaC)
+    idx = torch.zeros((1, 1), dtype=torch.long)
+    out_topk = model.generate(idx, max_new_tokens=2, top_k=1)
+    assert (out_topk[0, 1:] == 0).all()
+    out_topp = model.generate(idx, max_new_tokens=2, top_p=0.5)
+    assert (out_topp[0, 1:] == 0).all()


### PR DESCRIPTION
## Summary
- support temperature, top-k, and top-p sampling in `IndianaC.generate`
- forward sampling controls through `generate_text` and `generate_with_think`
- expose `--temperature`, `--top-k`, and `--top-p` options in CLI and add tests

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_688e50994ea48329900a64dd03d6c041