### PR TITLE
feat: order prompt search and test limit

### DIFF
--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -25,6 +25,21 @@ def generate_text(
     use_history: bool = False,
     history_limit: int = 3,
 ) -> str | tuple[str, dict[str, float | int]]:
+    """Generate a completion optionally enriched with past prompts.
+
+    Args:
+        prompt: Initial text to complete. If ``None`` the core prompt is used.
+        max_new_tokens: Maximum number of tokens to generate.
+        config: Optional model configuration.
+        log_reasoning: Whether to return reasoning metadata.
+        use_history: Fetch similar past prompts from :class:`SelfMonitor` and
+            prepend them to the provided prompt.
+        history_limit: Maximum number of historical prompts to include.
+
+    Returns:
+        The generated text. If ``log_reasoning`` is ``True`` a tuple of the text
+        and a dictionary with reasoning statistics is returned instead.
+    """
     prompt = prompt or CORE_PROMPT
     config = config or IndianaCConfig()
     monitor = SelfMonitor()

--- a/indiana_c/monitor.py
+++ b/indiana_c/monitor.py
@@ -68,7 +68,8 @@ class SelfMonitor:
         """Search previously logged prompts similar to the query."""
         cur = self.conn.cursor()
         cur.execute(
-            "SELECT prompt, output FROM prompts_index WHERE prompts_index MATCH ? LIMIT ?",
+            "SELECT prompt, output FROM prompts_index WHERE prompts_index MATCH ? "
+            "ORDER BY bm25(prompts_index) LIMIT ?",
             (query, limit),
         )
         return cur.fetchall()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -14,3 +14,16 @@ def test_search_prompts(tmp_path):
         assert ("hello world", "out1") in results
     finally:
         os.chdir(cwd)
+
+
+def test_search_prompts_limit(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
+        for i in range(3):
+            monitor.log(f"hello {i}", f"out{i}")
+        results = monitor.search_prompts("hello", limit=2)
+        assert len(results) == 2
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- rank prompt search results using FTS5 BM25
- document historical prompt mixing in generator
- test prompt search result limiting

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688e5323afd0832981af4c6b9f1b2ec6