### PR TITLE
Enable reflective self-verification in Indiana-C

### DIFF
--- a/indiana_c/__init__.py
+++ b/indiana_c/__init__.py
@@ -1,4 +1,5 @@
 from .generation import CORE_PROMPT, generate_text
+from .reflection import reflect
 from .model import IndianaC, IndianaCConfig
 from .monitor import SelfMonitor
 from .quantize import quantize_2bit
@@ -12,6 +13,7 @@ __all__ = [
     "IndianaC",
     "IndianaCConfig",
     "generate_text",
+    "reflect",
     "quantize_2bit",
     "SelfMonitor",
     "CORE_PROMPT",

--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -15,6 +15,11 @@ def main() -> None:
         default=1,
         help="number of attempts to ensure answer consistency",
     )
+    parser.add_argument(
+        "--reflect",
+        action="store_true",
+        help="enable self-verification through reflection",
+    )
     args = parser.parse_args()
 
     config = IndianaCConfig(vocab_size=256)
@@ -24,6 +29,7 @@ def main() -> None:
             n=args.consistency,
             max_new_tokens=args.max_new_tokens,
             config=config,
+            self_reflect=args.reflect,
         )
         print(result)
     else:
@@ -32,6 +38,7 @@ def main() -> None:
             max_new_tokens=args.max_new_tokens,
             config=config,
             log_reasoning=args.verbose,
+            self_reflect=args.reflect,
         )
         if args.verbose:
             text, meta = result

--- a/indiana_c/reflection.py
+++ b/indiana_c/reflection.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from .model import IndianaC, IndianaCConfig
+from .quantize import quantize_2bit
+from .tokenizer import tokenizer
+
+
+def reflect(prompt: str, draft: str, max_new_tokens: int = 50, config: IndianaCConfig | None = None) -> str:
+    """Critique a draft answer using the model.
+
+    Args:
+        prompt: The original prompt or question.
+        draft: The draft answer to critique.
+        max_new_tokens: Maximum tokens for the critique generation.
+        config: Optional model configuration.
+
+    Returns:
+        A string containing the model's critique of the draft answer.
+    """
+
+    critique_prompt = (
+        "Provide feedback on the given answer. "
+        f"Prompt: {prompt}\nAnswer: {draft}\nCritique:"
+    )
+    config = config or IndianaCConfig()
+    model = IndianaC(config)
+    quantize_2bit(model)
+    model.eval()
+    idx = tokenizer.encode(critique_prompt)
+    out = model.generate(idx, max_new_tokens=max_new_tokens)
+    critique = tokenizer.decode(out[0])
+    return critique

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from indiana_c.generation import generate_text
+from indiana_c.tokenizer import tokenizer
+
+
+class DummyMonitor:
+    def __init__(self, *_, **__):
+        pass
+
+    def search_prompts(self, *_args, **_kwargs):
+        return []
+
+    def log(self, *_args, **_kwargs):
+        pass
+
+
+def _patch_env():
+    return (
+        patch("indiana_c.generation.SelfMonitor", DummyMonitor),
+        patch("indiana_c.generation.quantize_2bit"),
+        patch(
+            "indiana_c.generation.thought_logger.log_turn",
+            return_value=SimpleNamespace(complexity=1, entropy=0.1, timestamp="t"),
+        ),
+    )
+
+
+def test_reflection_revises_answer_when_critique_negative() -> None:
+    draft = tokenizer.encode("draft")
+    revised = tokenizer.encode("revised")
+    p1, p2, p3 = _patch_env()
+    with (
+        p1,
+        p2,
+        p3,
+        patch("indiana_c.generation.reflect", return_value="Needs work"),
+        patch("indiana_c.generation.IndianaC") as MockModel,
+    ):
+        mock = MockModel.return_value
+        mock.generate.side_effect = [draft, revised]
+        mock.eval.return_value = None
+        result = generate_text("prompt", self_reflect=True)
+    assert result == tokenizer.decode(revised)
+    assert mock.generate.call_count == 2
+
+
+def test_reflection_keeps_answer_when_critique_positive() -> None:
+    draft = tokenizer.encode("draft")
+    p1, p2, p3 = _patch_env()
+    with (
+        p1,
+        p2,
+        p3,
+        patch("indiana_c.generation.reflect", return_value="Looks good"),
+        patch("indiana_c.generation.IndianaC") as MockModel,
+    ):
+        mock = MockModel.return_value
+        mock.generate.return_value = draft
+        mock.eval.return_value = None
+        result = generate_text("prompt", self_reflect=True)
+    assert result == tokenizer.decode(draft)
+    assert mock.generate.call_count == 1


### PR DESCRIPTION
## Summary
- add `reflect` function for model-based critique
- support optional self-reflection in generation pipeline
- expose `--reflect` flag in CLI and cover with tests

## Testing
- `flake8`
- `pytest -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688e52670788832985fb10b03b6c7870