### PR TITLE
Add reasoning loop with logging and CLI controls

### DIFF
--- a/indiana_c/__init__.py
+++ b/indiana_c/__init__.py
@@ -1,4 +1,4 @@
-from .generation import CORE_PROMPT, generate_text
+from .generation import CORE_PROMPT, generate_text, reason_loop
 from .reflection import reflect
 from .model import IndianaC, IndianaCConfig
 from .monitor import SelfMonitor
@@ -13,6 +13,7 @@ __all__ = [
     "IndianaC",
     "IndianaCConfig",
     "generate_text",
+    "reason_loop",
     "reflect",
     "quantize_2bit",
     "SelfMonitor",


### PR DESCRIPTION
## Summary
- add `reason_loop` helper that alternates between `<think>` and `<answer>` phases while logging each step
- expose `--max-steps` and `--stop-token` options in CLI to configure reasoning loop
- cover reasoning loop behaviour with new tests

## Testing
- `flake8 tests/test_reasoning.py indiana_c/generation.py indiana_c/cli.py indiana_c/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5a31e1b48329949288c23d60907a