### PR TITLE
Add configurable quantization precision

### DIFF
--- a/indiana_c/__init__.py
+++ b/indiana_c/__init__.py
@@ -2,7 +2,7 @@ from .generation import CORE_PROMPT, generate_text
 from .reflection import reflect
 from .model import IndianaC, IndianaCConfig
 from .monitor import SelfMonitor
-from .quantize import quantize_2bit
+from .quantize import quantize
 from .logger import (
     ThoughtComplexityLogger,
     estimate_complexity_and_entropy,
@@ -14,7 +14,7 @@ __all__ = [
     "IndianaCConfig",
     "generate_text",
     "reflect",
-    "quantize_2bit",
+    "quantize",
     "SelfMonitor",
     "CORE_PROMPT",
     "ThoughtComplexityLogger",

--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -10,6 +10,13 @@ def main() -> None:
     parser.add_argument("--max-new-tokens", type=int, default=50)
     parser.add_argument("--verbose", action="store_true", help="show reasoning log")
     parser.add_argument(
+        "--precision",
+        type=int,
+        choices=[2, 4, 8],
+        default=2,
+        help="weight quantization precision in bits",
+    )
+    parser.add_argument(
         "--consistency",
         type=int,
         default=1,
@@ -22,7 +29,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    config = IndianaCConfig(vocab_size=256)
+    config = IndianaCConfig(vocab_size=256, quantization_bits=args.precision)
     if args.consistency > 1:
         result = generate_consistent_text(
             args.prompt,

--- a/indiana_c/generation.py
+++ b/indiana_c/generation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from .model import IndianaC, IndianaCConfig
 from .monitor import SelfMonitor
-from .quantize import quantize_2bit
+from .quantize import quantize
 from .logger import (
     estimate_complexity_and_entropy,
     thought_logger,
@@ -51,7 +51,7 @@ def generate_text(
             combined = "\n".join(p for p, _ in history)
             prompt = f"{combined}\n{prompt}"
     model = IndianaC(config)
-    quantize_2bit(model)
+    quantize(model, config.quantization_bits)
     model.eval()
     idx = tokenizer.encode(prompt)
     out = model.generate(idx, max_new_tokens=max_new_tokens)

--- a/indiana_c/model.py
+++ b/indiana_c/model.py
@@ -17,6 +17,7 @@ class IndianaCConfig:
     n_head: int = 12
     n_embd: int = 768
     dropout: float = 0.0
+    quantization_bits: int = 2
 
     def __post_init__(self) -> None:
         if self.vocab_size is None:

--- a/indiana_c/reflection.py
+++ b/indiana_c/reflection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .model import IndianaC, IndianaCConfig
-from .quantize import quantize_2bit
+from .quantize import quantize
 from .tokenizer import tokenizer
 
 
@@ -24,7 +24,7 @@ def reflect(prompt: str, draft: str, max_new_tokens: int = 50, config: IndianaCC
     )
     config = config or IndianaCConfig()
     model = IndianaC(config)
-    quantize_2bit(model)
+    quantize(model, config.quantization_bits)
     model.eval()
     idx = tokenizer.encode(critique_prompt)
     out = model.generate(idx, max_new_tokens=max_new_tokens)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -19,7 +19,7 @@ class DummyMonitor:
 def _patch_env():
     return (
         patch("indiana_c.generation.SelfMonitor", DummyMonitor),
-        patch("indiana_c.generation.quantize_2bit"),
+        patch("indiana_c.generation.quantize"),
         patch(
             "indiana_c.generation.thought_logger.log_turn",
             return_value=SimpleNamespace(complexity=1, entropy=0.1, timestamp="t"),


### PR DESCRIPTION
## Summary
- Refactor weight quantization into a generic `quantize(model, bits)` with support for 2/4/8-bit precision and scaling.
- Allow choosing quantization precision via `IndianaCConfig` and the CLI.
- Apply configurable quantization during text generation and reflection.

## Testing
- `flake8 && echo flake8_passed`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu || true` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_688e5ca115fc8329b79e4e7bcd4837b3