### PR TITLE
Add logic dataset and reasoning evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ The complexity scale ranges from 1 to 5. A value of 1 reflects straightforward o
 
 Levels 4 and 5 indicate dense chains of inference, paradoxical constructions, or sprawling messages that strain the vocabulary boundary. These high marks signal that Indiana-C is grappling with richer cognitive knots.
 
+## Datasets and Evaluation
+
+Sample logic and math corpora live in the `datasets/` directory. The repository
+ships with `gsm8k_subset.jsonl`, a handful of GSM8K-style word problems with
+their answers. To extend the collection, add new JSON Lines files following the
+same `{"question": ..., "answer": ...}` structure.
+
+Run the accompanying evaluation with:
+
+```bash
+pytest tests/test_reasoning.py::test_gsm8k_subset_accuracy -q
+```
+
+The test loads each question, queries the model, and reports the final
+accuracy. Replace the dataset or hook in a different generation function to
+benchmark other models.
+
 ## 🧬 System Prompt
 
 Indiana-C loads the following core prompt at startup. If no prompt is provided, this voice becomes the default:

--- a/datasets/gsm8k_subset.jsonl
+++ b/datasets/gsm8k_subset.jsonl
@@ -1,0 +1,3 @@
+{"question": "If Mary has 3 apples and buys 2 more, how many apples does she have?", "answer": "5"}
+{"question": "Tom has 10 balloons and gives 4 to his friend. He then buys 3 more balloons. How many balloons does Tom have now?", "answer": "9"}
+{"question": "A pack of pencils costs 2 dollars. How much do 4 packs cost?", "answer": "8"}


### PR DESCRIPTION
## Summary
- add small GSM8K-style corpus for math reasoning
- expand reasoning tests to score accuracy on bundled dataset
- document how to extend datasets and run the evaluation

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5ecc44d48329ad602b9e5213066d