### PR TITLE
Add memory-based retrieval

### DIFF
--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -20,6 +20,11 @@ def main() -> None:
         action="store_true",
         help="enable self-verification through reflection",
     )
+    parser.add_argument(
+        "--use-memory",
+        action="store_true",
+        help="prepend similar past prompts from memory",
+    )
     parser.add_argument("--max-steps", type=int, default=0, help="max reasoning steps")
     parser.add_argument(
         "--stop-token",
@@ -48,6 +53,7 @@ def main() -> None:
             max_new_tokens=args.max_new_tokens,
             config=config,
             self_reflect=args.reflect,
+            use_memory=args.use_memory,
         )
         print(result)
     else:
@@ -57,6 +63,7 @@ def main() -> None:
             config=config,
             log_reasoning=args.verbose,
             self_reflect=args.reflect,
+            use_memory=args.use_memory,
         )
         if args.verbose:
             text, meta = result

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -3,27 +3,28 @@ import os
 from indiana_c.monitor import SelfMonitor
 
 
-def test_search_prompts(tmp_path):
+def test_search_exact(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
         monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
         monitor.log("hello world", "out1")
         monitor.log("another message", "out2")
-        results = monitor.search_prompts("hello")
+        results = monitor.search("hello world")
         assert ("hello world", "out1") in results
     finally:
         os.chdir(cwd)
 
 
-def test_search_prompts_limit(tmp_path):
+def test_search_tfidf_limit(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
         monitor = SelfMonitor(db_path=str(tmp_path / "mem.sqlite"))
         for i in range(3):
             monitor.log(f"hello {i}", f"out{i}")
-        results = monitor.search_prompts("hello", limit=2)
+        results = monitor.search("hello", limit=2)
         assert len(results) == 2
+        assert all("hello" in p for p, _ in results)
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
## Summary
- store prompt hashes in `SelfMonitor` and expose `search` combining SHA-256 and TF-IDF
- prepend retrieved prompt/response pairs in `generate_text`
- add `--use-memory` CLI flag to enable retrieval

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5edad9e08329982b89556946747e