### PR TITLE
Use indiana_core for text generation

### DIFF
--- a/indiana_c/cli.py
+++ b/indiana_c/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from .generation import generate_consistent_text, generate_text, reason_loop
+from indiana_core import generate_consistent_text, generate_text, reason_loop
 from .model import IndianaCConfig
 
 


### PR DESCRIPTION
## Summary
- switch CLI imports to use `indiana_core`'s text generation utilities

## Testing
- `flake8`
- `pytest`
- `python -m indiana_c.cli "2+2="`


------
https://chatgpt.com/codex/tasks/task_e_688e8003a0908329b2d3ba5b7f7fb7c5