### PR TITLE
Add test for empty prompt in generate endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app import app
@@ -9,5 +10,14 @@ def test_generate_endpoint_returns_response() -> None:
     client = TestClient(app)
     with patch("app.generate_text", return_value="ok"):
         resp = client.post("/generate", json={"prompt": "hi"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "ok"}
+
+
+@pytest.mark.parametrize("payload", [{}, {"prompt": ""}])
+def test_generate_empty_prompt(payload) -> None:
+    client = TestClient(app)
+    with patch("app.generate_text", return_value="ok"):
+        resp = client.post("/generate", json=payload)
     assert resp.status_code == 200
     assert resp.json() == {"response": "ok"}


### PR DESCRIPTION
## Summary
- test `/generate` handles missing or empty prompt without error

## Testing
- `python -m flake8 tests/test_api.py`
- `pytest tests/test_api.py::test_generate_empty_prompt -q`


------
https://chatgpt.com/codex/tasks/task_e_688e832ea7e88329afe0eab1719c0a3b