### PR TITLE
feat: add critique-driven reasoning loop

### DIFF
--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -57,7 +57,9 @@ def test_reason_loop_alternates_and_logs() -> None:
 
         def generate(self, idx, max_new_tokens):  # pragma: no cover - simple stub
             self.calls += 1
-            if self.calls % 2:
+            if self.calls == 1:
+                addition = tokenizer.encode(" plan")
+            elif self.calls == 2:
                 addition = tokenizer.encode(" thought")
             else:
                 addition = tokenizer.encode(" answer")
@@ -68,12 +70,51 @@ def test_reason_loop_alternates_and_logs() -> None:
         patch("indiana_core.quantize_2bit", lambda _: None),
         patch("indiana_core.SelfMonitor.__init__", return_value=None),
         patch("indiana_core.SelfMonitor.log") as mock_log,
+        patch("indiana_core.reflect", return_value="Looks good"),
+    ):
+        result = reason_loop("Q", max_steps=2)
+
+    assert isinstance(result, str)
+    assert [c[0][0] for c in mock_log.call_args_list] == [
+        "<plan>",
+        "<think>",
+        "<answer>",
+        "<critique>",
+    ]
+
+
+def test_reason_loop_revises_when_critique_negative() -> None:
+    """A negative critique should lead to an immediate revision."""
+
+    class DummyModel:
+        def __init__(self, *args, **kwargs) -> None:
+            self.calls = 0
+
+        def eval(self) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def generate(self, idx, max_new_tokens):  # pragma: no cover - simple stub
+            self.calls += 1
+            additions = [
+                " plan",
+                " thought",
+                " answer",
+                " revision",
+            ]
+            addition = tokenizer.encode(additions[self.calls - 1])
+            return torch.cat([idx, addition], dim=1)
+
+    with (
+        patch("indiana_core.IndianaC", DummyModel),
+        patch("indiana_core.quantize_2bit", lambda _: None),
+        patch("indiana_core.SelfMonitor.__init__", return_value=None),
+        patch("indiana_core.SelfMonitor.log"),
+        patch("indiana_core.reflect", return_value="Needs work"),
     ):
         result = reason_loop("Q", max_steps=1)
 
-    assert isinstance(result, str)
-    assert mock_log.call_args_list[0][0][0] == "<think>"
-    assert mock_log.call_args_list[1][0][0] == "<answer>"
+    expected = tokenizer.decode(tokenizer.encode(" revision"))
+    assert result == expected
 
 
 def test_gsm8k_subset_accuracy() -> None:


### PR DESCRIPTION
## Summary
- expand `reason_loop` to use plan→think→answer→critique phases with critique-based stopping and answer revision
- test negative critiques trigger revision
- test logging of plan/think/answer/critique phases

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec0b3a1d48329aa7c39ac14ca629b