### PR TITLE
Add code generation mode with FIM support

### DIFF
--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,14 @@
+from indiana_core import generate_code, tokenizer
+
+
+def test_tokenizer_handles_syntax_tokens() -> None:
+    tokens = tokenizer.encode("{}=")
+    assert tokens.shape[1] == 3
+    decoded = tokenizer.decode(tokens)
+    assert "{" in decoded and "}" in decoded and "=" in decoded
+
+
+def test_generate_code_infill_returns_string() -> None:
+    result = generate_code("a =", " b", max_new_tokens=2)
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
## Summary
- expand tokenizer vocabulary with code syntax and FIM tokens
- add `generate_code` for code completion and infill
- cover codegen with new tests

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec04946808329acde47b8b98df061