### PR TITLE
Add CoT generation and training utilities

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,39 @@
+"""Utilities for loading datasets from local files or HuggingFace hub."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from datasets import load_dataset as hf_load_dataset
+
+
+def load_dataset(source: str, split: str = "train") -> Iterable[Dict[str, Any]]:
+    """Yield samples from ``source``.
+
+    ``source`` may either be a path to a local JSONL/JSON/CSV file or the name of a
+    dataset on the HuggingFace hub. When a HuggingFace dataset name is provided the
+    ``split`` argument selects which split to stream.
+    """
+
+    path = Path(source)
+    if path.exists():
+        if path.suffix in {".jsonl", ".json"}:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        yield json.loads(line)
+        elif path.suffix == ".csv":
+            with path.open("r", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    yield row
+        else:
+            raise ValueError(f"Unsupported dataset extension: {path.suffix}")
+    else:
+        ds = hf_load_dataset(source, split=split)
+        for item in ds:
+            yield item

--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,58 @@
+"""Generate Chain-of-Thought traces using the Indiana-C model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, List
+
+from data_utils import load_dataset
+from indiana_core import reason_loop
+
+
+class SimpleMonitor:
+    """Minimal monitor that collects reasoning steps in memory."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, str]] = []
+
+    def log(self, prompt: str, output: str) -> None:
+        self.records.append({"prompt": prompt, "output": output})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate CoT traces with Indiana-C"
+    )
+    parser.add_argument("--dataset", required=True, help="Dataset path or HF name")
+    parser.add_argument("--output", required=True, help="Where to store JSONL results")
+    parser.add_argument("--split", default="train", help="Dataset split when using HF")
+    parser.add_argument("--prompt-key", default="question", help="Field containing the prompt")
+    parser.add_argument("--num-samples", type=int, default=None, help="Limit number of samples")
+    parser.add_argument("--max-steps", type=int, default=5, help="Reasoning steps")
+    parser.add_argument("--max-new-tokens", type=int, default=50)
+    args = parser.parse_args()
+
+    samples = load_dataset(args.dataset, split=args.split)
+    with open(args.output, "w", encoding="utf-8") as f:
+        for i, item in enumerate(samples):
+            prompt = item[args.prompt_key]
+            mon = SimpleMonitor()
+            final = reason_loop(
+                prompt,
+                max_steps=args.max_steps,
+                max_new_tokens=args.max_new_tokens,
+                monitor=mon,
+            )
+            json.dump(
+                {"prompt": prompt, "cot": mon.records, "final": final},
+                f,
+                ensure_ascii=False,
+            )
+            f.write("\n")
+            if args.num_samples is not None and i + 1 >= args.num_samples:
+                break
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 numpy
 tokenizers
 watchdog
+datasets

--- a/train.py
+++ b/train.py
@@ -1,0 +1,76 @@
+"""Simple fine-tuning utility for the Indiana-C model."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from data_utils import load_dataset
+from indiana_core import IndianaC, IndianaCConfig, tokenizer
+
+
+class TextDataset(Dataset):
+    """Tokenized dataset for supervised fine-tuning."""
+
+    def __init__(self, data: List[dict], prompt_key: str, response_key: str):
+        self.samples: List[torch.Tensor] = []
+        for item in data:
+            text = f"{item[prompt_key]}\n{item[response_key]}"
+            tokens = tokenizer.encode(text).squeeze(0)
+            self.samples.append(tokens)
+
+    def __len__(self) -> int:  # pragma: no cover - simple proxy
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        tokens = self.samples[idx]
+        return tokens[:-1], tokens[1:]
+
+
+def collate(batch: List[tuple[torch.Tensor, torch.Tensor]]):
+    xs, ys = zip(*batch)
+    max_len = max(x.size(0) for x in xs)
+    x_batch = torch.stack(
+        [torch.cat([x, torch.zeros(max_len - x.size(0), dtype=torch.long)]) for x in xs]
+    )
+    y_batch = torch.stack(
+        [torch.cat([y, torch.zeros(max_len - y.size(0), dtype=torch.long)]) for y in ys]
+    )
+    return x_batch, y_batch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune Indiana-C on a dataset")
+    parser.add_argument("--dataset", required=True, help="Dataset path or HF name")
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--prompt-key", default="prompt")
+    parser.add_argument("--response-key", default="answer")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--save", default="finetuned.pt", help="Model checkpoint path")
+    args = parser.parse_args()
+
+    data_list = list(load_dataset(args.dataset, split=args.split))
+    dataset = TextDataset(data_list, args.prompt_key, args.response_key)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, collate_fn=collate)
+
+    model = IndianaC(IndianaCConfig())
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    model.train()
+    for _ in range(args.epochs):
+        for x, y in loader:
+            optimizer.zero_grad()
+            _, loss = model(x, y)
+            loss.backward()
+            optimizer.step()
+
+    torch.save(model.state_dict(), args.save)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add datasets dependency and loader utility for local files or HuggingFace hub
- provide `generate.py` to create chain-of-thought traces using Indiana-C
- add `train.py` to fine-tune the model on arbitrary datasets

## Testing
- `python -m flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec03a80808329a57ee5f1d534cd2a