### PR TITLE
feat(logging): add lexical entropy and perplexity metrics

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -1,0 +1,49 @@
+import sys
+import importlib.machinery as _machinery
+import importlib.util as _util
+from collections import Counter
+import math
+
+# Load the standard library logging module under a different spec
+_spec = _machinery.PathFinder.find_spec("logging", sys.path[1:])
+if _spec and _spec.loader:
+    _stdlib_logging = _util.module_from_spec(_spec)
+    _spec.loader.exec_module(_stdlib_logging)
+    for _name in dir(_stdlib_logging):
+        if _name.startswith("__"):
+            continue
+        globals()[_name] = getattr(_stdlib_logging, _name)
+
+
+def lexical_entropy(text: str, n: int = 2) -> float:
+    """Compute normalized lexical entropy based on n-gram frequencies."""
+    tokens = text.split()
+    if len(tokens) < n:
+        return 0.0
+    ngrams = [tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+    counts = Counter(ngrams)
+    total = sum(counts.values())
+    if total == 0:
+        return 0.0
+    probs = [c / total for c in counts.values()]
+    entropy = -sum(p * math.log2(p) for p in probs)
+    max_entropy = math.log2(len(counts)) if len(counts) > 1 else 1.0
+    return float(entropy / max_entropy if max_entropy > 0 else 0.0)
+
+
+def simple_perplexity(text: str, tokenizer, model) -> float:
+    """Estimate perplexity of ``text`` using ``tokenizer`` and ``model``.
+
+    The model is expected to behave like ``IndianaC`` and return logits and
+    cross-entropy loss when called with ``(ids[:, :-1], ids[:, 1:])``.
+    """
+    import torch
+
+    with torch.no_grad():
+        ids = tokenizer.encode(text)
+        if ids.size(1) < 2:
+            return float("inf")
+        logits, loss = model(ids[:, :-1], ids[:, 1:])
+        if loss is None:
+            loss = torch.tensor(0.0)
+    return float(torch.exp(loss).item())

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -6,13 +6,15 @@ from indiana_core import (
 
 def test_estimate_complexity_and_entropy_keywords():
     msg = "This is a paradox that asks why it is recursive"
-    complexity, entropy = estimate_complexity_and_entropy(msg)
+    complexity, entropy, perplexity = estimate_complexity_and_entropy(msg)
     assert complexity >= 3
     assert 0 <= entropy <= 1
+    assert perplexity > 0
 
 
 def test_logger_records_and_recent():
     logger = ThoughtComplexityLogger(log_file="logs/test_log.jsonl")
-    entry = logger.log_turn("test message", 2, 0.5)
+    entry = logger.log_turn("test message", 2, 0.5, 10.0)
     assert entry.complexity == 2
     assert logger.recent(1)[0].message == "test message"
+    assert entry.perplexity == 10.0

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -20,8 +20,13 @@ def _patch_env():
         patch("indiana_core.SelfMonitor", DummyMonitor),
         patch("indiana_core.quantize_2bit"),
         patch(
+            "indiana_core.estimate_complexity_and_entropy", return_value=(1, 0.1, 1.0)
+        ),
+        patch(
             "indiana_core.thought_logger.log_turn",
-            return_value=SimpleNamespace(complexity=1, entropy=0.1, timestamp="t"),
+            return_value=SimpleNamespace(
+                complexity=1, entropy=0.1, perplexity=1.0, timestamp="t"
+            ),
         ),
     )
 
@@ -29,11 +34,12 @@ def _patch_env():
 def test_reflection_revises_answer_when_critique_negative() -> None:
     draft = tokenizer.encode("draft")
     revised = tokenizer.encode("revised")
-    p1, p2, p3 = _patch_env()
+    p1, p2, p3, p4 = _patch_env()
     with (
         p1,
         p2,
         p3,
+        p4,
         patch("indiana_core.reflect", return_value="Needs work"),
         patch("indiana_core.IndianaC") as MockModel,
     ):
@@ -47,11 +53,12 @@ def test_reflection_revises_answer_when_critique_negative() -> None:
 
 def test_reflection_keeps_answer_when_critique_positive() -> None:
     draft = tokenizer.encode("draft")
-    p1, p2, p3 = _patch_env()
+    p1, p2, p3, p4 = _patch_env()
     with (
         p1,
         p2,
         p3,
+        p4,
         patch("indiana_core.reflect", return_value="Looks good"),
         patch("indiana_core.IndianaC") as MockModel,
     ):


### PR DESCRIPTION
## Summary
- add lexical entropy computation from n-gram frequencies
- expose simple model-based perplexity metric
- track perplexity in thought logger and extend tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec017fa508329b68d37d7b7c4903d