### PR TITLE
Register monitor cleanup with atexit

### DIFF
--- a/indiana_core.py
+++ b/indiana_core.py
@@ -9,6 +9,7 @@ module.
 from __future__ import annotations
 
 import argparse
+import atexit
 import hashlib
 import json
 import math
@@ -404,10 +405,13 @@ class SelfMonitor:
 
     def stop_watchers(self) -> None:
         """Stop all active directory watchers."""
-        for observer in self.observers.values():
+        observers = getattr(self, "observers", None)
+        if not observers:
+            return
+        for observer in observers.values():
             observer.stop()
             observer.join()
-        self.observers.clear()
+        observers.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -423,6 +427,7 @@ def get_monitor() -> SelfMonitor:
     global _monitor_instance
     if _monitor_instance is None or not isinstance(_monitor_instance, SelfMonitor):
         _monitor_instance = SelfMonitor()
+        atexit.register(_monitor_instance.stop_watchers)
     return _monitor_instance
 
 

--- a/tests/test_monitor_atexit.py
+++ b/tests/test_monitor_atexit.py
@@ -1,0 +1,33 @@
+import atexit
+import os
+import time
+from pathlib import Path
+
+import indiana_core
+
+
+def test_monitor_stops_watchers_on_atexit(tmp_path, monkeypatch):
+    callbacks = []
+
+    def fake_register(func, *args, **kwargs):
+        callbacks.append((func, args, kwargs))
+        return func
+
+    monkeypatch.setattr(atexit, "register", fake_register)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    ds = Path("datasets")
+    ds.mkdir()
+    try:
+        monitor = indiana_core.get_monitor()
+        time.sleep(0.1)
+        assert monitor.observers
+        assert all(obs.is_alive() for obs in monitor.observers.values())
+        assert len(callbacks) == 1
+        for func, args, kwargs in callbacks:
+            func(*args, **kwargs)
+        assert not monitor.observers
+    finally:
+        indiana_core._monitor_instance = None
+        os.chdir(cwd)

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -14,6 +14,9 @@ class DummyMonitor:
     def log(self, *_args, **_kwargs):
         pass
 
+    def stop_watchers(self):
+        pass
+
 
 def _patch_env():
     return (


### PR DESCRIPTION
## Summary
- ensure `get_monitor` registers `stop_watchers` with `atexit`
- harden `stop_watchers` and test that atexit callbacks stop watchers
- add no-op `stop_watchers` to `DummyMonitor` used in reflection tests

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebf90e7408329a668feb39461ec3a