### PR TITLE
feat: cache quantized models

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from indiana_core import MODEL_CACHE
+
+
+@pytest.fixture(autouse=True)
+def clear_model_cache():
+    MODEL_CACHE.clear()
+    yield
+    MODEL_CACHE.clear()

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from indiana_core import IndianaCConfig, generate_text, tokenizer
+
+
+def test_model_cache_reuses_model() -> None:
+    config = IndianaCConfig()
+    with patch("indiana_core.IndianaC") as MockModel, patch(
+        "indiana_core.quantize_2bit"
+    ) as mock_quant:
+        instance = MockModel.return_value
+        instance.generate.return_value = tokenizer.encode("ok")
+        instance.eval.return_value = None
+        generate_text("prompt", config=config)
+        generate_text("prompt", config=config)
+    assert MockModel.call_count == 1
+    assert mock_quant.call_count == 1


### PR DESCRIPTION
## Summary
- cache quantized models by configuration to avoid repeated setup
- reuse cached model in text generation and reasoning helpers
- test model cache and clear between tests

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebf8224108329975f6066030e8d15