### PR TITLE
feat: log reasoning steps

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -6,13 +6,21 @@ from indiana_core import (
 
 def test_estimate_complexity_and_entropy_keywords():
     msg = "This is a paradox that asks why it is recursive"
-    complexity, entropy = estimate_complexity_and_entropy(msg)
+    complexity, entropy, steps = estimate_complexity_and_entropy(msg)
     assert complexity >= 3
     assert 0 <= entropy <= 1
+    assert steps == 0
+
+
+def test_estimate_complexity_and_entropy_counts_steps():
+    msg = "Step 1: analyze\nStep 2: conclude"
+    _, _, steps = estimate_complexity_and_entropy(msg)
+    assert steps == 2
 
 
 def test_logger_records_and_recent():
     logger = ThoughtComplexityLogger(log_file="logs/test_log.jsonl")
-    entry = logger.log_turn("test message", 2, 0.5)
+    entry = logger.log_turn("test message", 2, 0.5, 3)
     assert entry.complexity == 2
+    assert entry.steps == 3
     assert logger.recent(1)[0].message == "test message"

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -21,7 +21,7 @@ def _patch_env():
         patch("indiana_core.quantize_2bit"),
         patch(
             "indiana_core.thought_logger.log_turn",
-            return_value=SimpleNamespace(complexity=1, entropy=0.1, timestamp="t"),
+            return_value=SimpleNamespace(complexity=1, entropy=0.1, steps=0, timestamp="t"),
         ),
     )
 


### PR DESCRIPTION
## Summary
- track reasoning step matches when estimating complexity and entropy
- store and expose step counts in thought logs
- show step counts in verbose CLI output

## Testing
- `python -m flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ebf73e5208329baeaafead6aebd57