### PR TITLE
Add tokenizer training script and tests

### DIFF
--- a/scripts/train_tokenizer.py
+++ b/scripts/train_tokenizer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from tokenizers import Tokenizer
+from tokenizers.models import BPE
+from tokenizers.pre_tokenizers import ByteLevel
+from tokenizers.trainers import BpeTrainer
+
+
+def iter_texts() -> list[str]:
+    root = Path(__file__).resolve().parents[1]
+    datasets_dir = root / "datasets"
+    for path in datasets_dir.glob("*"):
+        if path.suffix == ".jsonl":
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    item = json.loads(line)
+                    for value in item.values():
+                        if isinstance(value, str):
+                            yield value
+        elif path.suffix == ".csv":
+            with path.open(encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    for key, value in row.items():
+                        if key.lower() in {"line", "text"} and value:
+                            yield value
+        else:
+            continue
+
+
+def main() -> None:
+    tokenizer = Tokenizer(BPE(unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = ByteLevel()
+    trainer = BpeTrainer(special_tokens=["[UNK]"])
+    tokenizer.train_from_iterator(iter_texts(), trainer)
+    out_path = Path(__file__).resolve().parents[1] / "tokenizer.json"
+    tokenizer.save(str(out_path))
+    print(f"Saved tokenizer to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,19 @@
+from indiana_core import tokenizer
+
+
+def has_token(token: str) -> bool:
+    return tokenizer.token_to_id(token) is not None
+
+
+def word_in_vocab(word: str) -> bool:
+    return has_token(word) or has_token("Ġ" + word)
+
+
+def test_basic_chars_present():
+    assert has_token("a")
+    assert has_token("b")
+
+
+def test_dataset_words_present():
+    assert word_in_vocab("Mary")
+    assert word_in_vocab("apples")

--- a/tokenizer.json
+++ b/tokenizer.json
@@ -1,0 +1,22500 @@
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {
+      "id": 0,
+      "content": "[UNK]",
+      "single_word": false,
+      "lstrip": false,
+      "rstrip": false,
+      "normalized": false,
+      "special": true
+    }
+  ],
+  "normalizer": null,
+  "pre_tokenizer": {
+    "type": "ByteLevel",
+    "add_prefix_space": true,
+    "trim_offsets": true,
+    "use_regex": true
+  },
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "[UNK]",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": false,
+    "ignore_merges": false,
+    "vocab": {
+      "[UNK]": 0,
+      "!": 1,
+      "\"": 2,
+      "%": 3,
+      "'": 4,
+      ",": 5,
+      "-": 6,
+      ".": 7,
+      "0": 8,
+      "1": 9,
+      "2": 10,
+      "3": 11,
+      "4": 12,
+      "5": 13,
+      "7": 14,
+      "8": 15,
+      "9": 16,
+      ":": 17,
+      ";": 18,
+      "?": 19,
+      "A": 20,
+      "B": 21,
+      "C": 22,
+      "D": 23,
+      "E": 24,
+      "F": 25,
+      "G": 26,
+      "H": 27,
+      "I": 28,
+      "J": 29,
+      "K": 30,
+      "L": 31,
+      "M": 32,
+      "N": 33,
+      "O": 34,
+      "P": 35,
+      "Q": 36,
+      "R": 37,
+      "S": 38,
+      "T": 39,
+      "U": 40,
+      "V": 41,
+      "W": 42,
+      "X": 43,
+      "Y": 44,
+      "Z": 45,
+      "a": 46,
+      "b": 47,
+      "c": 48,
+      "d": 49,
+      "e": 50,
+      "f": 51,
+      "g": 52,
+      "h": 53,
+      "i": 54,
+      "j": 55,
+      "k": 56,
+      "l": 57,
+      "m": 58,
+      "n": 59,
+      "o": 60,
+      "p": 61,
+      "q": 62,
+      "r": 63,
+      "s": 64,
+      "t": 65,
+      "u": 66,
+      "v": 67,
+      "w": 68,
+      "x": 69,
+      "y": 70,
+      "z": 71,
+      "â": 72,
+      "Ġ": 73,
+      "Ģ": 74,
+      "ĵ": 75,
+      "Ġt": 76,
+      "he": 77,
+      "ou": 78,
+      "Ġa": 79,
+      "in": 80,
+      "Ġw": 81,
+      "ĠI": 82,
+      "Ġs": 83,
+      "re": 84,
+      "on": 85,
+      "ha": 86,
+      "Ġy": 87,
+      "it": 88,
+      "Ġb": 89,
+      "Ġm": 90,
+      "Ġyou": 91,
+      "Ġthe": 92,
+      "Ġd": 93,
+      "Ġg": 94,
+      "Ġf": 95,
+      "ll": 96,
+      "er": 97,
+      "hat": 98,
+      "an": 99,
+      "is": 100,
+      "Ġc": 101,
+      "'s": 102,
+      "nd": 103,
+      "Ġo": 104,
+      "es": 105,
+      "Ġto": 106,
+      "ot": 107,
+      "Ġl": 108,
+      "ĠW": 109,
+      "Ġn": 110,
+      "ck": 111,
+      "Ġit": 112,
+      "or": 113,
+      "ow": 114,
+      "Ġp": 115,
+      "'t": 116,
+      "ar": 117,
+      "et": 118,
+      "Ġth": 119,
+      "Ġhe": 120,
+      "en": 121,
+      "as": 122,
+      "Ġin": 123,
+      "ed": 124,
+      "ĠT": 125,
+      "ing": 126,
+      "Ġof": 127,
+      "us": 128,
+      "le": 129,
+      "ve": 130,
+      "at": 131,
+      "Ġbe": 132,
+      "Ġand": 133,
+      "uck": 134,
+      "oo": 135,
+      "Ġthat": 136,
+      "Ġh": 137,
+      "ke": 138,
+      "ĠY": 139,
+      "Ġon": 140,
+      "om": 141,
+      "ay": 142,
+      "id": 143,
+      "Ġme": 144,
+      "ut": 145,
+      "Ġha": 146,
+      "ell": 147,
+      "Ġdo": 148,
+      "gh": 149,
+      "al": 150,
+      "Ġe": 151,
+      "ĠM": 152,
+      "out": 153,
+      "..": 154,
+      "Ġsh": 155,
+      "ld": 156,
+      "ĠA": 157,
+      "ĠB": 158,
+      "Ġis": 159,
+      "'m": 160,
+      "Ġfuck": 161,
+      "Ġk": 162,
+      "ch": 163,
+      "Ġyour": 164,
+      "'re": 165,
+      "ĠYou": 166,
+      "ad": 167,
+      "Ġdon": 168,
+      "Ġthis": 169,
+      "ce": 170,
+      "am": 171,
+      "ver": 172,
+      "ĠH": 173,
+      "ri": 174,
+      "ght": 175,
+      "ĠN": 176,
+      "na": 177,
+      "ĠS": 178,
+      "Ġwe": 179,
+      "Ġwas": 180,
+      "Ġmy": 181,
+      "im": 182,
+      "Ġwhat": 183,
+      "if": 184,
+      "Ġst": 185,
+      "âĢ": 186,
+      "ĠâĢ": 187,
+      "her": 188,
+      "ĠWhat": 189,
+      "ĠâĢĵ": 190,
+      "all": 191,
+      "Ġas": 192,
+      "Ġan": 193,
+      "ill": 194,
+      "Ġu": 195,
+      "Ġfuckin": 196,
+      "ent": 197,
+      "ĠD": 198,
+      "Ġgo": 199,
+      "Ġli": 200,
+      "ould": 201,
+      "ĠThe": 202,
+      "Ġj": 203,
+      "Ġkn": 204,
+      "st": 205,
+      "Ġwit": 206,
+      "Ġre": 207,
+      "Ġgon": 208,
+      "Ġgot": 209,
+      "Ġfor": 210,
+      "ie": 211,
+      "ust": 212,
+      "Ġgonna": 213,
+      "ro": 214,
+      "ĠJ": 215,
+      "Ġknow": 216,
+      "em": 217,
+      "Ġ'": 218,
+      "Ġwith": 219,
+      "Ġget": 220,
+      "Ġlike": 221,
+      "ĠIt": 222,
+      "Ġout": 223,
+      "Ġne": 224,
+      "se": 225,
+      "Ġman": 226,
+      "...": 227,
+      "ct": 228,
+      "ive": 229,
+      "ant": 230,
+      "Ġup": 231,
+      "ir": 232,
+      "Ġthey": 233,
+      "ho": 234,
+      "Ġnot": 235,
+      "bout": 236,
+      "ĠC": 237,
+      "Ġdid": 238,
+      "ood": 239,
+      "Ġshit": 240,
+      "'ll": 241,
+      "ĠG": 242,
+      "ag": 243,
+      "ĠF": 244,
+      "ook": 245,
+      "ake": 246,
+      "ion": 247,
+      "ĠO": 248,
+      "Ġno": 249,
+      "ome": 250,
+      "ĠBut": 251,
+      "il": 252,
+      "op": 253,
+      "un": 254,
+      "ig": 255,
+      "Ġjust": 256,
+      "ak": 257,
+      "Ġone": 258,
+      "ack": 259,
+      "ter": 260,
+      "Ġain": 261,
+      "ink": 262,
+      "Ġse": 263,
+      "ind": 264,
+      "Ġher": 265,
+      "Ġhere": 266,
+      "ore": 267,
+      "hen": 268,
+      "Ġabout": 269,
+      "ars": 270,
+      "ly": 271,
+      "od": 272,
+      "ta": 273,
+      "ess": 274,
+      "ry": 275,
+      "Ġbut": 276,
+      "Ġcan": 277,
+      "other": 278,
+      "ĠWe": 279,
+      "ea": 280,
+      "pp": 281,
+      "ers": 282,
+      "alk": 283,
+      "ĠAnd": 284,
+      "ĠP": 285,
+      "Ġif": 286,
+      "ight": 287,
+      "ur": 288,
+      "ĠL": 289,
+      "ĠThat": 290,
+      "Ġhave": 291,
+      "ĠWell": 292,
+      "ame": 293,
+      "right": 294,
+      "ĠNo": 295,
+      "ra": 296,
+      "Ġall": 297,
+      "Ġwant": 298,
+      "ast": 299,
+      "rou": 300,
+      "ul": 301,
+      "ĠR": 302,
+      "qu": 303,
+      "Ġthere": 304,
+      "Ġde": 305,
+      "and": 306,
+      "ble": 307,
+      "ĠV": 308,
+      "Ġnow": 309,
+      "Ġhis": 310,
+      "Ġass": 311,
+      "th": 312,
+      "Ġright": 313,
+      "Ġat": 314,
+      "Ġwhen": 315,
+      "itt": 316,
+      "Ġor": 317,
+      "Ġthink": 318,
+      "ĠNow": 319,
+      "Ġare": 320,
+      "Ġwat": 321,
+      "Ġso": 322,
+      "Ġshe": 323,
+      "Ġsay": 324,
+      "os": 325,
+      "Ġ\"": 326,
+      "Ġgood": 327,
+      "Ġfr": 328,
+      "ace": 329,
+      "ic": 330,
+      "Ġmean": 331,
+      "ellus": 332,
+      "ĠHe": 333,
+      "arsellus": 334,
+      "Ġwho": 335,
+      "art": 336,
+      "use": 337,
+      "ĠMarsellus": 338,
+      "Ġnever": 339,
+      "Ġwor": 340,
+      "ĠIf": 341,
+      "one": 342,
+      "Ġany": 343,
+      "ick": 344,
+      "ven": 345,
+      "Ġtalk": 346,
+      "our": 347,
+      "Ġcall": 348,
+      "Ġpl": 349,
+      "ĠDon": 350,
+      "age": 351,
+      "oy": 352,
+      "uy": 353,
+      "Ġtell": 354,
+      "Ġsu": 355,
+      "Ġever": 356,
+      "Ġwatch": 357,
+      "ee": 358,
+      "fuck": 359,
+      "ol": 360,
+      "ty": 361,
+      "Ġwould": 362,
+      "own": 363,
+      "ass": 364,
+      "ool": 365,
+      "otherfuck": 366,
+      "ab": 367,
+      "pe": 368,
+      "Ġya": 369,
+      "Ġbl": 370,
+      "Ġcar": 371,
+      "est": 372,
+      "Ġex": 373,
+      "ĠVin": 374,
+      "wo": 375,
+      "Ġgive": 376,
+      "ĠTh": 377,
+      "Ġoff": 378,
+      "ĠJim": 379,
+      "ody": 380,
+      "Ġfrom": 381,
+      "ber": 382,
+      "dam": 383,
+      "ger": 384,
+      "ĠE": 385,
+      "Ġus": 386,
+      "Ġtake": 387,
+      "Ġsome": 388,
+      "Ġmotherfuck": 389,
+      "Ġlook": 390,
+      "Ġhow": 391,
+      "Ġhad": 392,
+      "Ġneed": 393,
+      "ac": 394,
+      "cent": 395,
+      "nt": 396,
+      "oot": 397,
+      "ous": 398,
+      "Ġsa": 399,
+      "anna": 400,
+      "Ġlitt": 401,
+      "ate": 402,
+      "ime": 403,
+      "Ġlittle": 404,
+      "'ve": 405,
+      "ca": 406,
+      "kay": 407,
+      "Ġqu": 408,
+      "ine": 409,
+      "ong": 410,
+      "Ġback": 411,
+      "Ġcould": 412,
+      "Ġcool": 413,
+      "Ġthing": 414,
+      "ife": 415,
+      "ĠJimm": 416,
+      "hy": 417,
+      "Ġtime": 418,
+      "han": 419,
+      "Ġbet": 420,
+      "Ġlet": 421,
+      "Ġpro": 422,
+      "Ġhear": 423,
+      "Ġint": 424,
+      "omet": 425,
+      "Ġdoes": 426,
+      "Ġshould": 427,
+      "ĠSo": 428,
+      "ĠJimmie": 429,
+      "body": 430,
+      "ep": 431,
+      "end": 432,
+      "Ġtwo": 433,
+      "Ġway": 434,
+      "Ġwanna": 435,
+      "Ġsomet": 436,
+      "Ġdown": 437,
+      "Ġhand": 438,
+      "Ġdidn": 439,
+      "eah": 440,
+      "hi": 441,
+      "ny": 442,
+      "here": 443,
+      "Ġthrou": 444,
+      "ĠHow": 445,
+      "ĠThey": 446,
+      "Ġsometh": 447,
+      "Ġthrough": 448,
+      "'d": 449,
+      "ĠU": 450,
+      "Ġr": 451,
+      "ret": 452,
+      "Ġguy": 453,
+      "Ġover": 454,
+      "Ġhim": 455,
+      "ĠYeah": 456,
+      "ide": 457,
+      "Ġdead": 458,
+      "cause": 459,
+      "ge": 460,
+      "ies": 461,
+      "ue": 462,
+      "um": 463,
+      "Ġro": 464,
+      "Ġwill": 465,
+      "red": 466,
+      "ont": 467,
+      "Ġcom": 468,
+      "Ġle": 469,
+      "ation": 470,
+      "Ġhapp": 471,
+      "ally": 472,
+      "Ġgotta": 473,
+      "ĠJul": 474,
+      "ĠVincent": 475,
+      "ĠThis": 476,
+      "au": 477,
+      "ain": 478,
+      "dy": 479,
+      "get": 480,
+      "lf": 481,
+      "ne": 482,
+      "vin": 483,
+      "Ġ...": 484,
+      "Ġbr": 485,
+      "Ġby": 486,
+      "Ġmass": 487,
+      "Ġday": 488,
+      "Ġfind": 489,
+      "Ġco": 490,
+      "Ġlo": 491,
+      "Ġname": 492,
+      "ase": 493,
+      "Ġshot": 494,
+      "Ġkill": 495,
+      "Ġrem": 496,
+      "act": 497,
+      "Ġour": 498,
+      "Ġsame": 499,
+      "reak": 500,
+      "Ġbit": 501,
+      "Ġmake": 502,
+      "Ġmore": 503,
+      "Ġgre": 504,
+      "ish": 505,
+      "Ġwere": 506,
+      "ĠButch": 507,
+      "ĠJules": 508,
+      ".\"": 509,
+      "ci": 510,
+      "ice": 511,
+      "ĠK": 512,
+      "ren": 513,
+      "Ġfight": 514,
+      "Ġfoot": 515,
+      "Ġcou": 516,
+      "Ġbeen": 517,
+      "Ġshow": 518,
+      "ĠDo": 519,
+      "ĠThen": 520,
+      "Ġjo": 521,
+      "ember": 522,
+      "irst": 523,
+      "ĠGod": 524,
+      "Ġinto": 525,
+      "ap": 526,
+      "are": 527,
+      "ff": 528,
+      "ose": 529,
+      "ther": 530,
+      "way": 531,
+      "ree": 532,
+      "Ġbig": 533,
+      "Ġdr": 534,
+      "ist": 535,
+      "orry": 536,
+      "Ġpr": 537,
+      "Ġthose": 538,
+      "ĠYes": 539,
+      "Ġdoin": 540,
+      "riend": 541,
+      "Ġask": 542,
+      "Ġtalkin": 543,
+      "damn": 544,
+      "Ġmotherfucker": 545,
+      "be": 546,
+      "eop": 547,
+      "ock": 548,
+      "ure": 549,
+      "ouse": 550,
+      "Ġag": 551,
+      "Ġal": 552,
+      "Ġsp": 553,
+      "Ġgun": 554,
+      "Ġfirst": 555,
+      "ance": 556,
+      "nder": 557,
+      "Ġtoo": 558,
+      "ark": 559,
+      "Ġsee": 560,
+      "blem": 561,
+      "oney": 562,
+      "Ġsaid": 563,
+      "Ġproblem": 564,
+      "Ġhappen": 565,
+      "Ġmassage": 566,
+      "eople": 567,
+      "ia": 568,
+      "ox": 569,
+      "rand": 570,
+      "ull": 571,
+      "we": 572,
+      "Ġke": 573,
+      "Ġthan": 574,
+      "Ġgi": 575,
+      "ank": 576,
+      "Ġother": 577,
+      "ese": 578,
+      "Ġlot": 579,
+      "ĠWho": 580,
+      "Ġpeople": 581,
+      "Ġhome": 582,
+      "ĠShe": 583,
+      "ĠOh": 584,
+      "ĠOkay": 585,
+      "ĠLook": 586,
+      "thing": 587,
+      "Ġplace": 588,
+      "Ġbetter": 589,
+      "Ġremember": 590,
+      "cc": 591,
+      "ew": 592,
+      "ect": 593,
+      "for": 594,
+      "hone": 595,
+      "ng": 596,
+      "Ġv": 597,
+      "Ġtr": 598,
+      "ought": 599,
+      "Ġwalk": 600,
+      "Ġwife": 601,
+      "Ġsha": 602,
+      "res": 603,
+      "ite": 604,
+      "Ġbreak": 605,
+      "Ġmo": 606,
+      "Ġfriend": 607,
+      "ĠWall": 608,
+      "Ġnig": 609,
+      "orn": 610,
+      "Ġhouse": 611,
+      "Ġgod": 612,
+      "ster": 613,
+      "round": 614,
+      "Ġgreat": 615,
+      "ĠWallace": 616,
+      "'.": 617,
+      "ait": 618,
+      "ave": 619,
+      "fore": 620,
+      "lp": 621,
+      "ple": 622,
+      "ud": 623,
+      "wn": 624,
+      "Ġwhy": 625,
+      "Ġwhere": 626,
+      "Ġsit": 627,
+      "Ġspe": 628,
+      "Ġsorry": 629,
+      "ity": 630,
+      "Ġboy": 631,
+      "Ġthen": 632,
+      "Ġfat": 633,
+      "Ġfive": 634,
+      "Ġch": 635,
+      "Ġcha": 636,
+      "Ġcle": 637,
+      "Ġhelp": 638,
+      "Ġeat": 639,
+      "Ġeven": 640,
+      "ĠMar": 641,
+      "ĠMia": 642,
+      "ĠAm": 643,
+      "ĠNot": 644,
+      "Ġstill": 645,
+      "ĠDid": 646,
+      "Ġreal": 647,
+      "Ġforget": 648,
+      "Ġnoth": 649,
+      "ĠOne": 650,
+      "akes": 651,
+      "Ġsure": 652,
+      "aby": 653,
+      "hich": 654,
+      "Ġsomething": 655,
+      "Ġguys": 656,
+      "Ġlove": 657,
+      "Ġdrink": 658,
+      "Ġagain": 659,
+      "Ġgoddamn": 660,
+      "fast": 661,
+      "pt": 662,
+      "uch": 663,
+      "ĠQ": 664,
+      "iness": 665,
+      "Ġwon": 666,
+      "Ġwait": 667,
+      "Ġsm": 668,
+      "Ġbus": 669,
+      "Ġbook": 670,
+      "Ġbaby": 671,
+      "Ġmorn": 672,
+      "Ġfast": 673,
+      "Ġcont": 674,
+      "Ġokay": 675,
+      "Ġpie": 676,
+      "lem": 677,
+      "Ġbefore": 678,
+      "Ġhas": 679,
+      "ĠAre": 680,
+      "ady": 681,
+      "addy": 682,
+      "very": 683,
+      "Ġstop": 684,
+      "ĠChe": 685,
+      "ĠFor": 686,
+      "unch": 687,
+      "Ġwork": 688,
+      "Ġevery": 689,
+      "Ġheard": 690,
+      "retty": 691,
+      "Ġbreakfast": 692,
+      "Ġclean": 693,
+      "Ġbusiness": 694,
+      "gar": 695,
+      "gers": 696,
+      "oll": 697,
+      "uation": 698,
+      "ye": 699,
+      "ound": 700,
+      "Ġwr": 701,
+      "Ġbad": 702,
+      "Ġbuy": 703,
+      "Ġbank": 704,
+      "Ġmin": 705,
+      "Ġmet": 706,
+      "Ġmuch": 707,
+      "Ġdif": 708,
+      "Ġdie": 709,
+      "Ġfif": 710,
+      "iss": 711,
+      "Ġcome": 712,
+      "Ġtom": 713,
+      "Ġtold": 714,
+      "Ġlea": 715,
+      "Ġpot": 716,
+      "ets": 717,
+      "Ġthree": 718,
+      "ath": 719,
+      "oom": 720,
+      "ute": 721,
+      "ĠMe": 722,
+      "ĠMr": 723,
+      "ĠMy": 724,
+      "ĠSt": 725,
+      "Ġun": 726,
+      "Ġunder": 727,
+      "Ġgoin": 728,
+      "self": 729,
+      "osed": 730,
+      "Ġcalled": 731,
+      "eel": 732,
+      "Ġsomethin": 733,
+      "Ġrob": 734,
+      "Ġbitch": 735,
+      "ffee": 736,
+      "Ġkeep": 737,
+      "Ġsituation": 738,
+      "Ġdiff": 739,
+      "?!": 740,
+      "Zed": 741,
+      "ces": 742,
+      "cle": 743,
+      "gal": 744,
+      "hu": 745,
+      "ier": 746,
+      "les": 747,
+      "less": 748,
+      "ness": 749,
+      "old": 750,
+      "pen": 751,
+      "up": 752,
+      "ĠZed": 753,
+      "Ġtast": 754,
+      "hed": 755,
+      "Ġapp": 756,
+      "Ġacc": 757,
+      "Ġwent": 758,
+      "ither": 759,
+      "Ġmay": 760,
+      "Ġmad": 761,
+      "Ġmir": 762,
+      "Ġthem": 763,
+      "Ġdi": 764,
+      "Ġgrand": 765,
+      "Ġfe": 766,
+      "Ġfeel": 767,
+      "ise": 768,
+      "Ġlife": 769,
+      "Ġlau": 770,
+      "ĠWhen": 771,
+      "ĠWhy": 772,
+      "Ġple": 773,
+      "Ġput": 774,
+      "Ġpop": 775,
+      "Ġphone": 776,
+      "Ġhell": 777,
+      "Ġheart": 778,
+      "ĠTell": 779,
+      "Ġbel": 780,
+      "Ġbell": 781,
+      "ides": 782,
+      "Ġeither": 783,
+      "Ġstor": 784,
+      "Ġstart": 785,
+      "entlem": 786,
+      "Ġreally": 787,
+      "ĠJust": 788,
+      "ĠGood": 789,
+      "oss": 790,
+      "Ġanything": 791,
+      "pect": 792,
+      "ĠVince": 793,
+      "Ġnigger": 794,
+      "Ġmorning": 795,
+      "entlemen": 796,
+      "'?": 797,
+      "av": 798,
+      "aw": 799,
+      "ere": 800,
+      "iz": 801,
+      "li": 802,
+      "lo": 803,
+      "nie": 804,
+      "pl": 805,
+      "per": 806,
+      "ror": 807,
+      "room": 808,
+      "vent": 809,
+      "vil": 810,
+      "wan": 811,
+      "Ġid": 812,
+      "Ġad": 813,
+      "Ġaround": 814,
+      "Ġwind": 815,
+      "Ġwhich": 816,
+      "ĠIn": 817,
+      "ĠIs": 818,
+      "rect": 819,
+      "ons": 820,
+      "Ġye": 821,
+      "Ġbur": 822,
+      "Ġbunch": 823,
+      "Ġmind": 824,
+      "Ġtheir": 825,
+      "Ġgu": 826,
+      "Ġgit": 827,
+      "Ġgar": 828,
+      "Ġgentlemen": 829,
+      "Ġfell": 830,
+      "Ġfact": 831,
+      "Ġcl": 832,
+      "ĠWol": 833,
+      "ĠWhere": 834,
+      "ora": 835,
+      "Ġpo": 836,
+      "Ġthought": 837,
+      "leep": 838,
+      "ato": 839,
+      "ĠBon": 840,
+      "ĠBig": 841,
+      "Ġfucked": 842,
+      "Ġkind": 843,
+      "ĠYour": 844,
+      "ĠSure": 845,
+      "Ġstore": 846,
+      "Ġret": 847,
+      "ĠCan": 848,
+      "unny": 849,
+      "Ġseem": 850,
+      "ĠLet": 851,
+      "ract": 852,
+      "Ġfront": 853,
+      "ical": 854,
+      "ĠHey": 855,
+      "Ġblack": 856,
+      "Ġquack": 857,
+      "Ġhands": 858,
+      "hile": 859,
+      "ĠUn": 860,
+      "rett": 861,
+      "Ġlegal": 862,
+      "Ġbring": 863,
+      "Ġcoffee": 864,
+      "Ġcouple": 865,
+      "Ġhappened": 866,
+      "Ġshake": 867,
+      "ĠQu": 868,
+      "ĠCheese": 869,
+      "Ġtomato": 870,
+      "Ġbelie": 871,
+      "Ġwindow": 872,
+      "ĠWolf": 873,
+      "',": 874,
+      "ach": 875,
+      "ey": 876,
+      "fter": 877,
+      "ien": 878,
+      "ible": 879,
+      "ner": 880,
+      "oke": 881,
+      "ped": 882,
+      "pher": 883,
+      "rd": 884,
+      "row": 885,
+      "te": 886,
+      "ves": 887,
+      "ving": 888,
+      "ze": 889,
+      "Ġim": 890,
+      "Ġte": 891,
+      "Ġtry": 892,
+      "ount": 893,
+      "Ġab": 894,
+      "Ġam": 895,
+      "Ġact": 896,
+      "Ġwall": 897,
+      "Ġsleep": 898,
+      "ream": 899,
+      "ond": 900,
+      "onal": 901,
+      "Ġbed": 902,
+      "Ġball": 903,
+      "Ġbull": 904,
+      "Ġmom": 905,
+      "Ġmoney": 906,
+      "Ġdri": 907,
+      "Ġgir": 908,
+      "Ġgave": 909,
+      "Ġfil": 910,
+      "Ġface": 911,
+      "ans": 912,
+      "ister": 913,
+      "Ġown": 914,
+      "Ġluck": 915,
+      "Ġlast": 916,
+      "Ġlong": 917,
+      "ĠWin": 918,
+      "orm": 919,
+      "ort": 920,
+      "Ġpers": 921,
+      "Ġpick": 922,
+      "Ġpretty": 923,
+      "Ġpier": 924,
+      "ard": 925,
+      "Ġbecause": 926,
+      "Ġhu": 927,
+      "Ġhit": 928,
+      "Ġonly": 929,
+      "Ġdoll": 930,
+      "Ġevil": 931,
+      "ĠMac": 932,
+      "ĠAn": 933,
+      "ĠAll": 934,
+      "ĠAnt": 935,
+      "ĠBrett": 936,
+      "Ġdone": 937,
+      "amp": 938,
+      "Ġstick": 939,
+      "Ġgoes": 940,
+      "Ġgoing": 941,
+      "ĠThere": 942,
+      "stand": 943,
+      "Ġoutta": 944,
+      "ants": 945,
+      "Ġupon": 946,
+      "ĠFuck": 947,
+      "ĠFab": 948,
+      "ign": 949,
+      "pposed": 950,
+      "urt": 951,
+      "ĠRock": 952,
+      "anda": 953,
+      "thy": 954,
+      "ittin": 955,
+      "Ġsayin": 956,
+      "Ġmeans": 957,
+      "Ġworld": 958,
+      "Ġsupposed": 959,
+      "Ġwouldn": 960,
+      "Ġlooks": 961,
+      "acle": 962,
+      "Ġbetwe": 963,
+      "Ġdoesn": 964,
+      "Ġhandle": 965,
+      "ĠUh": 966,
+      "Ġroad": 967,
+      "Ġcomes": 968,
+      "aught": 969,
+      "Ġdays": 970,
+      "Ġjob": 971,
+      "sterdam": 972,
+      "ĠAmsterdam": 973,
+      "Ġnothin": 974,
+      "Ġwrong": 975,
+      "Ġleave": 976,
+      "Ġunderstand": 977,
+      "Ġmiracle": 978,
+      "Ġlaugh": 979,
+      "Ġbelly": 980,
+      "Ġidea": 981,
+      "Ġyears": 982,
+      "Ġguess": 983,
+      "ĠBonnie": 984,
+      "Ġkinda": 985,
+      "Ġbelieve": 986,
+      "pherd": 987,
+      "Ġfilthy": 988,
+      "ĠAntwan": 989,
+      "Ġbetween": 990,
+      ",\"": 991,
+      "What": 992,
+      "ale": 993,
+      "able": 994,
+      "cakes": 995,
+      "eg": 996,
+      "el": 997,
+      "eous": 998,
+      "ful": 999,
+      "gs": 1000,
+      "io": 1001,
+      "ip": 1002,
+      "ix": 1003,
+      "ious": 1004,
+      "ks": 1005,
+      "pa": 1006,
+      "ss": 1007,
+      "side": 1008,
+      "wer": 1009,
+      "xic": 1010,
+      "Ġ2": 1011,
+      "Ġen": 1012,
+      "Ġuse": 1013,
+      "Ġven": 1014,
+      "Ġvery": 1015,
+      "Ġty": 1016,
+      "Ġtou": 1017,
+      "Ġtak": 1018,
+      "hes": 1019,
+      "ough": 1020,
+      "Ġaway": 1021,
+      "int": 1022,
+      "Ġsound": 1023,
+      "ony": 1024,
+      "Ġyet": 1025,
+      "Ġbag": 1026,
+      "Ġmen": 1027,
+      "Ġmed": 1028,
+      "Ġdam": 1029,
+      "Ġgl": 1030,
+      "Ġfine": 1031,
+      "ancakes": 1032,
+      "Ġcase": 1033,
+      "Ġcare": 1034,
+      "Ġold": 1035,
+      "esides": 1036,
+      "Ġnice": 1037,
+      "orc": 1038,
+      "ord": 1039,
+      "orror": 1040,
+      "orrect": 1041,
+      "Ġper": 1042,
+      "Ġpri": 1043,
+      "Ġpancakes": 1044,
+      "ary": 1045,
+      "ĠTake": 1046,
+      "ated": 1047,
+      "Ġhurt": 1048,
+      "ĠYol": 1049,
+      "Ġonce": 1050,
+      "omise": 1051,
+      "Ġmeant": 1052,
+      "Ġhard": 1053,
+      "ello": 1054,
+      "Ġdoing": 1055,
+      "Ġel": 1056,
+      "Ġear": 1057,
+      "Ġeach": 1058,
+      "ĠMon": 1059,
+      "ĠMay": 1060,
+      "Ġshoot": 1061,
+      "ĠAny": 1062,
+      "ĠBe": 1063,
+      "ĠBesides": 1064,
+      "Ġyours": 1065,
+      "Ġyourself": 1066,
+      "ĠHorror": 1067,
+      "ĠHello": 1068,
+      "ried": 1069,
+      "ĠSh": 1070,
+      "ĠSay": 1071,
+      "Ġstra": 1072,
+      "alley": 1073,
+      "illion": 1074,
+      "Ġknew": 1075,
+      "rop": 1076,
+      "Ġgett": 1077,
+      "Ġmany": 1078,
+      "ĠGot": 1079,
+      "ions": 1080,
+      "Ġseen": 1081,
+      "rain": 1082,
+      "Ġrighteous": 1083,
+      "Ġatt": 1084,
+      "Ġshepherd": 1085,
+      "Ġword": 1086,
+      "Ġanybody": 1087,
+      "Ġsugar": 1088,
+      "Ġwoulda": 1089,
+      "Ġblood": 1090,
+      "Ġexact": 1091,
+      "berry": 1092,
+      "ĠEx": 1093,
+      "Ġmotherfuckers": 1094,
+      "Ġsaw": 1095,
+      "Ġquest": 1096,
+      "geance": 1097,
+      "ueberry": 1098,
+      "umm": 1099,
+      "Ġcomin": 1100,
+      "Ġbrother": 1101,
+      "Ġshows": 1102,
+      "ress": 1103,
+      "Ġfather": 1104,
+      "Ġchill": 1105,
+      "Ġcharact": 1106,
+      "ĠMexic": 1107,
+      "huh": 1108,
+      "Ġmade": 1109,
+      "teen": 1110,
+      "Ġgirl": 1111,
+      "ormal": 1112,
+      "ĠRocky": 1113,
+      "Ġvengeance": 1114,
+      "Ġmedical": 1115,
+      "Ġdamn": 1116,
+      "ĠYolanda": 1117,
+      "Ġcharacter": 1118,
+      "bit": 1119,
+      "bur": 1120,
+      "co": 1121,
+      "cha": 1122,
+      "com": 1123,
+      "cess": 1124,
+      "der": 1125,
+      "ec": 1126,
+      "eal": 1127,
+      "ft": 1128,
+      "fin": 1129,
+      "fta": 1130,
+      "ire": 1131,
+      "ian": 1132,
+      "mit": 1133,
+      "oe": 1134,
+      "oons": 1135,
+      "pin": 1136,
+      "til": 1137,
+      "uri": 1138,
+      "wood": 1139,
+      "Ġes": 1140,
+      "Ġill": 1141,
+      "Ġra": 1142,
+      "Ġtw": 1143,
+      "Ġwell": 1144,
+      "Ġsc": 1145,
+      "Ġsl": 1146,
+      "Ġsy": 1147,
+      "Ġser": 1148,
+      "read": 1149,
+      "had": 1150,
+      "ition": 1151,
+      "Ġbum": 1152,
+      "Ġbox": 1153,
+      "Ġmakes": 1154,
+      "Ġmillion": 1155,
+      "Ġdou": 1156,
+      "Ġdis": 1157,
+      "Ġdark": 1158,
+      "Ġdream": 1159,
+      "Ġfar": 1160,
+      "Ġfour": 1161,
+      "Ġfreak": 1162,
+      "eral": 1163,
+      "ang": 1164,
+      "ison": 1165,
+      "Ġcr": 1166,
+      "Ġcho": 1167,
+      "Ġcop": 1168,
+      "Ġchan": 1169,
+      "Ġcaught": 1170,
+      "Ġopen": 1171,
+      "Ġlay": 1172,
+      "ĠWould": 1173,
+      "Ġnormal": 1174,
+      "Ġpart": 1175,
+      "Ġhead": 1176,
+      "Ġinter": 1177,
+      "ĠTV": 1178,
+      "ĠTo": 1179,
+      "ĠThan": 1180,
+      "ĠTony": 1181,
+      "ingo": 1182,
+      "ather": 1183,
+      "Ġbeg": 1184,
+      "Ġhold": 1185,
+      "ident": 1186,
+      "utes": 1187,
+      "Ġhang": 1188,
+      "Ġhafta": 1189,
+      "Ġdoor": 1190,
+      "ĠBur": 1191,
+      "ĠBora": 1192,
+      "ĠHoney": 1193,
+      "ĠHave": 1194,
+      "ĠNaw": 1195,
+      "ĠSp": 1196,
+      "Ġwasn": 1197,
+      "imal": 1198,
+      "ific": 1199,
+      "Ġstay": 1200,
+      "Ġanimal": 1201,
+      "ĠDaddy": 1202,
+      "Ġlive": 1203,
+      "sta": 1204,
+      "ston": 1205,
+      "Ġwitness": 1206,
+      "Ġreg": 1207,
+      "Ġready": 1208,
+      "ĠCh": 1209,
+      "ĠGet": 1210,
+      "ages": 1211,
+      "ĠFl": 1212,
+      "ĠFive": 1213,
+      "Ġnobody": 1214,
+      "ily": 1215,
+      "unn": 1216,
+      "Ġself": 1217,
+      "tain": 1218,
+      "table": 1219,
+      "ĠRa": 1220,
+      "ĠRingo": 1221,
+      "quor": 1222,
+      "Ġdefin": 1223,
+      "Ġthinkin": 1224,
+      "Ġplac": 1225,
+      "Ġtellin": 1226,
+      "Ġblow": 1227,
+      "ĠEvery": 1228,
+      "Ġmotherfuckin": 1229,
+      "Ġcoulda": 1230,
+      "Ġleft": 1231,
+      "Ġhappy": 1232,
+      "Ġkilled": 1233,
+      "cial": 1234,
+      "ĠKn": 1235,
+      "Ġcount": 1236,
+      "Ġjok": 1237,
+      "Ġpromise": 1238,
+      "itely": 1239,
+      "Ġspecial": 1240,
+      "Ġchick": 1241,
+      "ĠMarvin": 1242,
+      "Ġnothing": 1243,
+      "Ġminutes": 1244,
+      "Ġfifteen": 1245,
+      "Ġtaste": 1246,
+      "Ġmaybe": 1247,
+      "Ġdiv": 1248,
+      "Ġfeet": 1249,
+      "Ġpleas": 1250,
+      "avor": 1251,
+      "ĠUncle": 1252,
+      "ienne": 1253,
+      "ĠWinston": 1254,
+      "Ġpersonal": 1255,
+      "Ġdollars": 1256,
+      "ĠFabienne": 1257,
+      "Ġtouch": 1258,
+      "Ġtakin": 1259,
+      "Ġstraight": 1260,
+      "Ġquestion": 1261,
+      "burgers": 1262,
+      "urious": 1263,
+      "Ġdefinitely": 1264,
+      "Ġplaces": 1265,
+      "?\"": 1266,
+      "aul": 1267,
+      "bt": 1268,
+      "boy": 1269,
+      "bab": 1270,
+      "bye": 1271,
+      "chen": 1272,
+      "ched": 1273,
+      "de": 1274,
+      "daddy": 1275,
+      "ead": 1276,
+      "eren": 1277,
+      "father": 1278,
+      "grand": 1279,
+      "hh": 1280,
+      "ib": 1281,
+      "ied": 1282,
+      "ired": 1283,
+      "ma": 1284,
+      "mo": 1285,
+      "man": 1286,
+      "mor": 1287,
+      "ment": 1288,
+      "mare": 1289,
+      "part": 1290,
+      "park": 1291,
+      "ran": 1292,
+      "swer": 1293,
+      "smare": 1294,
+      "ui": 1295,
+      "uff": 1296,
+      "ya": 1297,
+      "zy": 1298,
+      "Ġ1": 1299,
+      "Ġz": 1300,
+      "Ġent": 1301,
+      "Ġust": 1302,
+      "Ġtong": 1303,
+      "Ġtable": 1304,
+      "head": 1305,
+      "ounder": 1306,
+      "Ġac": 1307,
+      "Ġapart": 1308,
+      "Ġwin": 1309,
+      "Ġwar": 1310,
+      "Ġsk": 1311,
+      "Ġson": 1312,
+      "Ġsen": 1313,
+      "Ġsil": 1314,
+      "Ġsign": 1315,
+      "Ġsittin": 1316,
+      "Ġsix": 1317,
+      "reci": 1318,
+      "onight": 1319,
+      "Ġyes": 1320,
+      "ities": 1321,
+      "itchen": 1322,
+      "Ġbes": 1323,
+      "Ġbot": 1324,
+      "Ġbar": 1325,
+      "Ġbest": 1326,
+      "Ġbody": 1327,
+      "Ġbrain": 1328,
+      "Ġmot": 1329,
+      "Ġmat": 1330,
+      "Ġmine": 1331,
+      "Ġmark": 1332,
+      "Ġdan": 1333,
+      "Ġdes": 1334,
+      "Ġdunn": 1335,
+      "Ġfore": 1336,
+      "Ġfunny": 1337,
+      "Ġfavor": 1338,
+      "Ġche": 1339,
+      "Ġcame": 1340,
+      "Ġcup": 1341,
+      "Ġcamp": 1342,
+      "ndred": 1343,
+      "Ġtowe": 1344,
+      "Ġtown": 1345,
+      "Ġlate": 1346,
+      "ĠWhich": 1347,
+      "ĠWhile": 1348,
+      "ĠWhad": 1349,
+      "Ġpil": 1350,
+      "Ġpos": 1351,
+      "Ġpath": 1352,
+      "arter": 1353,
+      "Ġhero": 1354,
+      "aster": 1355,
+      "ĠTr": 1356,
+      "ating": 1357,
+      "Ġbeer": 1358,
+      "Ġhid": 1359,
+      "idge": 1360,
+      "Ġmeet": 1361,
+      "Ġmemor": 1362,
+      "uth": 1363,
+      "Ġdog": 1364,
+      "aline": 1365,
+      "Ġeas": 1366,
+      "outh": 1367,
+      "lda": 1368,
+      "ĠAbout": 1369,
+      "ĠAfter": 1370,
+      "ĠBl": 1371,
+      "Ġkitchen": 1372,
+      "adio": 1373,
+      "cept": 1374,
+      "ĠHoll": 1375,
+      "ric": 1376,
+      "ĠSee": 1377,
+      "ĠSorry": 1378,
+      "Ġwear": 1379,
+      "Ġweak": 1380,
+      "Ġwash": 1381,
+      "Ġmyself": 1382,
+      "Ġstri": 1383,
+      "Ġanother": 1384,
+      "enty": 1385,
+      "ĠDan": 1386,
+      "Ġliquor": 1387,
+      "Ġres": 1388,
+      "Ġread": 1389,
+      "Ġgone": 1390,
+      "Ġforg": 1391,
+      "ĠJoe": 1392,
+      "Ġnew": 1393,
+      "Ġnecess": 1394,
+      "irty": 1395,
+      "ĠGo": 1396,
+      "ĠGive": 1397,
+      "ility": 1398,
+      "ope": 1399,
+      "Ġsec": 1400,
+      "Ġsex": 1401,
+      "pper": 1402,
+      "ĠPretty": 1403,
+      "ĠPounder": 1404,
+      "raid": 1405,
+      "ĠRed": 1406,
+      "ĠRoy": 1407,
+      "quel": 1408,
+      "Ġorder": 1409,
+      "Ġsoon": 1410,
+      "Ġsoap": 1411,
+      "ĠHere": 1412,
+      "Ġwatchin": 1413,
+      "olo": 1414,
+      "oolidge": 1415,
+      "Ġblueberry": 1416,
+      "Ġexpect": 1417,
+      "Ġexper": 1418,
+      "ĠThree": 1419,
+      "dammit": 1420,
+      "Ġsomebody": 1421,
+      "Ġlookin": 1422,
+      "Ġlooking": 1423,
+      "Ġneedle": 1424,
+      "Ġcouldn": 1425,
+      "Ġprobab": 1426,
+      "Ġring": 1427,
+      "Ġradio": 1428,
+      "dya": 1429,
+      "Ġlost": 1430,
+      "renaline": 1431,
+      "ĠGoddamn": 1432,
+      "ways": 1433,
+      "Ġalways": 1434,
+      "Ġtook": 1435,
+      "Ġproblems": 1436,
+      "Ġgiven": 1437,
+      "Ġgivin": 1438,
+      "fortable": 1439,
+      "Ġvalley": 1440,
+      "Ġtruth": 1441,
+      "Ġmove": 1442,
+      "Ġmost": 1443,
+      "Ġniggers": 1444,
+      "uddy": 1445,
+      "Ġspeak": 1446,
+      "Ġchar": 1447,
+      "ĠMarily": 1448,
+      "ĠNoth": 1449,
+      "Ġsmart": 1450,
+      "Ġcontest": 1451,
+      "Ġhash": 1452,
+      "Ġstopped": 1453,
+      "ĠForce": 1454,
+      "Ġworked": 1455,
+      "Ġbuys": 1456,
+      "Ġbanks": 1457,
+      "Ġminute": 1458,
+      "Ġrobber": 1459,
+      "Ġdiffere": 1460,
+      "Ġdifferen": 1461,
+      "Ġappreci": 1462,
+      "Ġaccount": 1463,
+      "Ġaccident": 1464,
+      "Ġgrandfather": 1465,
+      "Ġplease": 1466,
+      "Ġstory": 1467,
+      "erest": 1468,
+      "vention": 1469,
+      "Ġadrenaline": 1470,
+      "Ġburger": 1471,
+      "Ġgarage": 1472,
+      "Ġpoint": 1473,
+      "Ġstores": 1474,
+      "ĠQuarter": 1475,
+      "Ġimp": 1476,
+      "Ġtele": 1477,
+      "Ġwallets": 1478,
+      "Ġbedroom": 1479,
+      "Ġballpark": 1480,
+      "Ġbullets": 1481,
+      "Ġmoment": 1482,
+      "Ġpierce": 1483,
+      "Ġhundred": 1484,
+      "Ġstickin": 1485,
+      "Ġenough": 1486,
+      "Ġtyran": 1487,
+      "Ġglass": 1488,
+      "Ġelse": 1489,
+      "Ġearth": 1490,
+      "ĠBecause": 1491,
+      "Ġexactly": 1492,
+      "Ġserious": 1493,
+      "Ġdoubt": 1494,
+      "Ġdarkness": 1495,
+      "ĠBurger": 1496,
+      "Ġwitnessed": 1497,
+      "Ġregister": 1498,
+      "Ġselfish": 1499,
+      "ĠRaquel": 1500,
+      "granddaddy": 1501,
+      "smarelda": 1502,
+      "Ġusta": 1503,
+      "Ġtongue": 1504,
+      "Ġapartment": 1505,
+      "Ġdanger": 1506,
+      "Ġdunno": 1507,
+      "Ġtowel": 1508,
+      "ĠWhaddya": 1509,
+      "Ġpilot": 1510,
+      "Ġnecessary": 1511,
+      "ĠRoyale": 1512,
+      "Ġprobably": 1513,
+      "ĠMarilyn": 1514,
+      "Ġdifferent": 1515,
+      "Ġtyranny": 1516,
+      "00": 1517,
+      "17": 1518,
+      "Ca": 1519,
+      "The": 1520,
+      "Vin": 1521,
+      "ai": 1522,
+      "ail": 1523,
+      "ahu": 1524,
+      "by": 1525,
+      "band": 1526,
+      "bage": 1527,
+      "cl": 1528,
+      "con": 1529,
+      "cing": 1530,
+      "cus": 1531,
+      "cri": 1532,
+      "ches": 1533,
+      "day": 1534,
+      "dad": 1535,
+      "doll": 1536,
+      "ever": 1537,
+      "eak": 1538,
+      "equ": 1539,
+      "fect": 1540,
+      "fied": 1541,
+      "fraid": 1542,
+      "gun": 1543,
+      "hit": 1544,
+      "hind": 1545,
+      "hite": 1546,
+      "iet": 1547,
+      "iest": 1548,
+      "ject": 1549,
+      "ken": 1550,
+      "kie": 1551,
+      "lt": 1552,
+      "lim": 1553,
+      "land": 1554,
+      "lish": 1555,
+      "mp": 1556,
+      "met": 1557,
+      "mers": 1558,
+      "ned": 1559,
+      "of": 1560,
+      "oly": 1561,
+      "phone": 1562,
+      "rad": 1563,
+      "rown": 1564,
+      "sa": 1565,
+      "so": 1566,
+      "su": 1567,
+      "sol": 1568,
+      "to": 1569,
+      "tun": 1570,
+      "two": 1571,
+      "ug": 1572,
+      "ually": 1573,
+      "ved": 1574,
+      "vill": 1575,
+      "vie": 1576,
+      "xt": 1577,
+      "yes": 1578,
+      "ycle": 1579,
+      "Ġve": 1580,
+      "Ġri": 1581,
+      "Ġtri": 1582,
+      "Ġtrou": 1583,
+      "Ġtonight": 1584,
+      "oun": 1585,
+      "Ġar": 1586,
+      "Ġafter": 1587,
+      "Ġafraid": 1588,
+      "ins": 1589,
+      "inny": 1590,
+      "inish": 1591,
+      "Ġwish": 1592,
+      "Ġset": 1593,
+      "Ġsides": 1594,
+      "reat": 1595,
+      "onz": 1596,
+      "onrad": 1597,
+      "Ġyell": 1598,
+      "Ġbas": 1599,
+      "Ġbro": 1600,
+      "Ġbir": 1601,
+      "Ġbath": 1602,
+      "Ġboss": 1603,
+      "Ġmag": 1604,
+      "Ġmess": 1605,
+      "Ġmouth": 1606,
+      "Ġthee": 1607,
+      "Ġthese": 1608,
+      "Ġdy": 1609,
+      "Ġdin": 1610,
+      "Ġdig": 1611,
+      "Ġdur": 1612,
+      "Ġdest": 1613,
+      "Ġdate": 1614,
+      "Ġdance": 1615,
+      "Ġgen": 1616,
+      "Ġgook": 1617,
+      "Ġgra": 1618,
+      "Ġgour": 1619,
+      "Ġgang": 1620,
+      "Ġfl": 1621,
+      "Ġfing": 1622,
+      "Ġfood": 1623,
+      "Ġfox": 1624,
+      "Ġfound": 1625,
+      "Ġflo": 1626,
+      "Ġfurious": 1627,
+      "Ġfaul": 1628,
+      "Ġfinish": 1629,
+      "llect": 1630,
+      "erv": 1631,
+      "ertain": 1632,
+      "anese": 1633,
+      "angar": 1634,
+      "isk": 1635,
+      "Ġcas": 1636,
+      "Ġcat": 1637,
+      "Ġcro": 1638,
+      "Ġcir": 1639,
+      "Ġcab": 1640,
+      "Ġcap": 1641,
+      "Ġcorrect": 1642,
+      "Ġcertain": 1643,
+      "Ġol": 1644,
+      "esus": 1645,
+      "Ġtop": 1646,
+      "Ġtoss": 1647,
+      "otect": 1648,
+      "othes": 1649,
+      "Ġless": 1650,
+      "Ġlady": 1651,
+      "ĠWar": 1652,
+      "ĠWill": 1653,
+      "ĠWanna": 1654,
+      "Ġnam": 1655,
+      "Ġnight": 1656,
+      "ork": 1657,
+      "Ġpa": 1658,
+      "Ġpig": 1659,
+      "Ġpack": 1660,
+      "Ġpass": 1661,
+      "Ġpunch": 1662,
+      "Ġpiss": 1663,
+      "Ġposs": 1664,
+      "aris": 1665,
+      "arcon": 1666,
+      "Ġthrow": 1667,
+      "Ġthrown": 1668,
+      "ence": 1669,
+      "ashed": 1670,
+      "Ġinst": 1671,
+      "Ġinside": 1672,
+      "Ġinequ": 1673,
+      "ederal": 1674,
+      "ush": 1675,
+      "usband": 1676,
+      "lease": 1677,
+      "Ġbec": 1678,
+      "Ġbeing": 1679,
+      "Ġbehind": 1680,
+      "Ġhill": 1681,
+      "Ġhour": 1682,
+      "Ġhoney": 1683,
+      "Ġhusband": 1684,
+      "omers": 1685,
+      "ider": 1686,
+      "Ġhalf": 1687,
+      "Ġeye": 1688,
+      "Ġeyes": 1689,
+      "ĠMer": 1690,
+      "ĠMong": 1691,
+      "Ġshop": 1692,
+      "ĠAun": 1693,
+      "ĠBunny": 1694,
+      "ĠBible": 1695,
+      "Ġkick": 1696,
+      "Ġkangar": 1697,
+      "ĠHi": 1698,
+      "ĠHea": 1699,
+      "ĠHond": 1700,
+      "ĠSe": 1701,
+      "ĠSom": 1702,
+      "Ġstab": 1703,
+      "Ġstuff": 1704,
+      "Ġsteak": 1705,
+      "Ġaside": 1706,
+      "Ġanger": 1707,
+      "Ġanswer": 1708,
+      "ĠDeal": 1709,
+      "stem": 1710,
+      "Ġresta": 1711,
+      "ustomers": 1712,
+      "roy": 1713,
+      "ĠJack": 1714,
+      "ĠJap": 1715,
+      "ĠJew": 1716,
+      "ĠJesus": 1717,
+      "empt": 1718,
+      "Ġmanag": 1719,
+      "ĠCome": 1720,
+      "ĠCorrect": 1721,
+      "ĠCoolidge": 1722,
+      "ĠConrad": 1723,
+      "ĠGinny": 1724,
+      "aged": 1725,
+      "ĠFonz": 1726,
+      "ĠOD": 1727,
+      "ĠOn": 1728,
+      "ilk": 1729,
+      "ilt": 1730,
+      "inded": 1731,
+      "pples": 1732,
+      "ĠParis": 1733,
+      "ĠPlease": 1734,
+      "urn": 1735,
+      "urs": 1736,
+      "urants": 1737,
+      "ĠLord": 1738,
+      "ĠNobody": 1739,
+      "Ġwanted": 1740,
+      "ular": 1741,
+      "ulip": 1742,
+      "ĠRes": 1743,
+      "ĠRight": 1744,
+      "Ġdeal": 1745,
+      "Ġdeath": 1746,
+      "Ġdeli": 1747,
+      "ĠVeg": 1748,
+      "Ġasses": 1749,
+      "Ġaren": 1750,
+      "Ġwhole": 1751,
+      "Ġworry": 1752,
+      "Ġworth": 1753,
+      "Ġplay": 1754,
+      "Ġplate": 1755,
+      "oyd": 1756,
+      "eep": 1757,
+      "otherfucker": 1758,
+      "Ġexec": 1759,
+      "Ġexcept": 1760,
+      "Ġoffend": 1761,
+      "ĠEng": 1762,
+      "ĠEze": 1763,
+      "Ġlooked": 1764,
+      "Ġquite": 1765,
+      "Ġthings": 1766,
+      "Ġinterest": 1767,
+      "Ġshoulda": 1768,
+      "ĠUu": 1769,
+      "Ġrisk": 1770,
+      "ump": 1771,
+      "Ġcomp": 1772,
+      "Ġlead": 1773,
+      "Ġmassages": 1774,
+      "Ġfinds": 1775,
+      "Ġcold": 1776,
+      "Ġcost": 1777,
+      "Ġcollect": 1778,
+      "Ġshotgun": 1779,
+      "Ġreminded": 1780,
+      "ĠKahu": 1781,
+      "ĠKeep": 1782,
+      "rench": 1783,
+      "Ġcoun": 1784,
+      "ĠDoes": 1785,
+      "Ġjoke": 1786,
+      "isten": 1787,
+      "Ġprotect": 1788,
+      "Ġalive": 1789,
+      "Ġspl": 1790,
+      "Ġhappens": 1791,
+      "Ġgives": 1792,
+      "Ġgiving": 1793,
+      "ĠWhoa": 1794,
+      "fortun": 1795,
+      "Ġmovie": 1796,
+      "please": 1797,
+      "udi": 1798,
+      "Ġspec": 1799,
+      "Ġboys": 1800,
+      "Ġevening": 1801,
+      "Ġsmoke": 1802,
+      "Ġcontin": 1803,
+      "Ġpieces": 1804,
+      "ĠForget": 1805,
+      "Ġeverything": 1806,
+      "Ġwrist": 1807,
+      "Ġmetric": 1808,
+      "Ġfifty": 1809,
+      "Ġleavin": 1810,
+      "utely": 1811,
+      "ĠStop": 1812,
+      "Ġunless": 1813,
+      "lessed": 1814,
+      "Ġtasty": 1815,
+      "Ġgranddad": 1816,
+      "Ġpoppa": 1817,
+      "Ġstorage": 1818,
+      "ized": 1819,
+      "venture": 1820,
+      "Ġadventure": 1821,
+      "Ġgarbage": 1822,
+      "Ġclothes": 1823,
+      "Ġpoison": 1824,
+      "Ġretard": 1825,
+      "Ġseems": 1826,
+      "Ġseemed": 1827,
+      "Ġtryin": 1828,
+      "Ġabsol": 1829,
+      "Ġballoons": 1830,
+      "Ġmomma": 1831,
+      "Ġdrive": 1832,
+      "Ġlucky": 1833,
+      "Ġpiercing": 1834,
+      "Ġ25": 1835,
+      "orced": 1836,
+      "orcycle": 1837,
+      "ĠMonro": 1838,
+      "ĠMonster": 1839,
+      "ĠMaybe": 1840,
+      "ĠShut": 1841,
+      "Ġgettin": 1842,
+      "Ġgetting": 1843,
+      "Ġattempt": 1844,
+      "Ġbloody": 1845,
+      "ummy": 1846,
+      "Ġbrothers": 1847,
+      "bitch": 1848,
+      "comfortable": 1849,
+      "Ġsystem": 1850,
+      "Ġboxing": 1851,
+      "Ġcrashed": 1852,
+      "Ġchopper": 1853,
+      "Ġcops": 1854,
+      "Ġpartner": 1855,
+      "ĠThanks": 1856,
+      "ĠFloyd": 1857,
+      "ĠEverybody": 1858,
+      "Ġcountry": 1859,
+      "Ġjokes": 1860,
+      "Ġdivorced": 1861,
+      "Ġpleasure": 1862,
+      "Ġpersonality": 1863,
+      "most": 1864,
+      "Ġskull": 1865,
+      "Ġbeset": 1866,
+      "Ġmotorcycle": 1867,
+      "Ġmarker": 1868,
+      "Ġdescri": 1869,
+      "Ġforever": 1870,
+      "Ġposition": 1871,
+      "Ġmemorized": 1872,
+      "ĠHolly": 1873,
+      "Ġstrike": 1874,
+      "oloid": 1875,
+      "Ġcharity": 1876,
+      "Ġcontestants": 1877,
+      "Ġrobbery": 1878,
+      "Ġdifference": 1879,
+      "Ġtelephone": 1880,
+      "Cause": 1881,
+      "Vincent": 1882,
+      "dollar": 1883,
+      "kiel": 1884,
+      "Ġtrouble": 1885,
+      "Ġbathroom": 1886,
+      "Ġmagic": 1887,
+      "Ġduring": 1888,
+      "Ġdestroy": 1889,
+      "Ġgourmet": 1890,
+      "Ġfloor": 1891,
+      "Ġfault": 1892,
+      "Ġcatch": 1893,
+      "Ġpassage": 1894,
+      "Ġinequities": 1895,
+      "ĠMongoloid": 1896,
+      "ĠAunt": 1897,
+      "Ġkangaroo": 1898,
+      "ĠHeaven": 1899,
+      "ĠHonda": 1900,
+      "ĠJapanese": 1901,
+      "Ġdeliver": 1902,
+      "ĠVega": 1903,
+      "ĠEnglish": 1904,
+      "ĠEzekiel": 1905,
+      "ĠKahuna": 1906,
+      "fortunate": 1907,
+      "Ġabsolutely": 1908,
+      "Ġdescribe": 1909,
+      "30": 1910,
+      "Donal": 1911,
+      "Dead": 1912,
+      "Esmarelda": 1913,
+      "Fox": 1914,
+      "IA": 1915,
+      "ON": 1916,
+      "UN": 1917,
+      "ax": 1918,
+      "aus": 1919,
+      "bed": 1920,
+      "bill": 1921,
+      "bbit": 1922,
+      "cou": 1923,
+      "ced": 1924,
+      "cuse": 1925,
+      "dd": 1926,
+      "do": 1927,
+      "den": 1928,
+      "ding": 1929,
+      "ered": 1930,
+      "ease": 1931,
+      "five": 1932,
+      "fant": 1933,
+      "gl": 1934,
+      "go": 1935,
+      "ged": 1936,
+      "ging": 1937,
+      "gry": 1938,
+      "gest": 1939,
+      "hic": 1940,
+      "house": 1941,
+      "iar": 1942,
+      "ike": 1943,
+      "igh": 1944,
+      "iven": 1945,
+      "ipe": 1946,
+      "kin": 1947,
+      "led": 1948,
+      "ling": 1949,
+      "lster": 1950,
+      "me": 1951,
+      "mm": 1952,
+      "med": 1953,
+      "more": 1954,
+      "mother": 1955,
+      "mburgers": 1956,
+      "nes": 1957,
+      "now": 1958,
+      "nam": 1959,
+      "oi": 1960,
+      "oan": 1961,
+      "offee": 1962,
+      "pit": 1963,
+      "ring": 1964,
+      "rist": 1965,
+      "rite": 1966,
+      "sh": 1967,
+      "si": 1968,
+      "sive": 1969,
+      "tom": 1970,
+      "tist": 1971,
+      "uly": 1972,
+      "uca": 1973,
+      "vis": 1974,
+      "vol": 1975,
+      "where": 1976,
+      "while": 1977,
+      "you": 1978,
+      "ying": 1979,
+      "Ġ-": 1980,
+      "Ġ.": 1981,
+      "Ġ3": 1982,
+      "Ġ4": 1983,
+      "Ġ8": 1984,
+      "Ġ9": 1985,
+      "Ġhat": 1986,
+      "Ġten": 1987,
+      "Ġtra": 1988,
+      "Ġtick": 1989,
+      "Ġtend": 1990,
+      "Ġtrop": 1991,
+      "Ġtrain": 1992,
+      "Ġturn": 1993,
+      "Ġtummy": 1994,
+      "hether": 1995,
+      "Ġahead": 1996,
+      "inen": 1997,
+      "ince": 1998,
+      "inci": 1999,
+      "Ġwet": 2000,
+      "Ġwed": 2001,
+      "Ġwom": 2002,
+      "Ġwore": 2003,
+      "Ġwine": 2004,
+      "Ġwhile": 2005,
+      "Ġwoke": 2006,
+      "ĠIng": 2007,
+      "Ġsw": 2008,
+      "Ġsat": 2009,
+      "Ġsell": 2010,
+      "Ġsink": 2011,
+      "Ġsca": 2012,
+      "Ġside": 2013,
+      "Ġsiz": 2014,
+      "rew": 2015,
+      "reet": 2016,
+      "reast": 2017,
+      "repa": 2018,
+      "onna": 2019,
+      "onable": 2020,
+      "hase": 2021,
+      "Ġyeah": 2022,
+      "itch": 2023,
+      "itive": 2024,
+      "Ġbo": 2025,
+      "Ġbu": 2026,
+      "Ġble": 2027,
+      "Ġbal": 2028,
+      "Ġbars": 2029,
+      "Ġbrou": 2030,
+      "Ġbare": 2031,
+      "Ġbought": 2032,
+      "Ġbui": 2033,
+      "Ġbuddy": 2034,
+      "Ġbreast": 2035,
+      "Ġmust": 2036,
+      "Ġmiss": 2037,
+      "Ġmister": 2038,
+      "Ġmaster": 2039,
+      "Ġdry": 2040,
+      "Ġdick": 2041,
+      "Ġdare": 2042,
+      "Ġdaddy": 2043,
+      "Ġdrop": 2044,
+      "Ġdread": 2045,
+      "Ġdirty": 2046,
+      "Ġgr": 2047,
+      "Ġgas": 2048,
+      "Ġfut": 2049,
+      "Ġfam": 2050,
+      "Ġfew": 2051,
+      "Ġfix": 2052,
+      "Ġfire": 2053,
+      "Ġfederal": 2054,
+      "llway": 2055,
+      "ery": 2056,
+      "eric": 2057,
+      "erfect": 2058,
+      "any": 2059,
+      "anish": 2060,
+      "anned": 2061,
+      "anoi": 2062,
+      "isit": 2063,
+      "isco": 2064,
+      "isfied": 2065,
+      "Ġcon": 2066,
+      "Ġcor": 2067,
+      "Ġcow": 2068,
+      "Ġcoo": 2069,
+      "Ġcell": 2070,
+      "Ġcra": 2071,
+      "Ġchi": 2072,
+      "Ġcorn": 2073,
+      "Ġcity": 2074,
+      "Ġcons": 2075,
+      "Ġcream": 2076,
+      "Ġcurious": 2077,
+      "Ġcease": 2078,
+      "ndo": 2079,
+      "ndry": 2080,
+      "Ġoak": 2081,
+      "Ġopin": 2082,
+      "Ġodd": 2083,
+      "Ġtoget": 2084,
+      "Ġla": 2085,
+      "Ġloy": 2086,
+      "Ġlisten": 2087,
+      "Ġlying": 2088,
+      "Ġlinen": 2089,
+      "ĠWor": 2090,
+      "ĠWant": 2091,
+      "ĠWake": 2092,
+      "ĠWhite": 2093,
+      "Ġni": 2094,
+      "Ġnut": 2095,
+      "Ġnerv": 2096,
+      "cks": 2097,
+      "Ġits": 2098,
+      "ors": 2099,
+      "orrow": 2100,
+      "orks": 2101,
+      "Ġph": 2102,
+      "Ġpar": 2103,
+      "Ġpen": 2104,
+      "Ġpal": 2105,
+      "Ġpur": 2106,
+      "Ġpock": 2107,
+      "Ġpull": 2108,
+      "Ġpres": 2109,
+      "Ġprepa": 2110,
+      "arch": 2111,
+      "arred": 2112,
+      "aria": 2113,
+      "arian": 2114,
+      "Ġthous": 2115,
+      "Ġthres": 2116,
+      "Ġthrew": 2117,
+      "ennes": 2118,
+      "ash": 2119,
+      "asonable": 2120,
+      "Ġinfor": 2121,
+      "Ġinvention": 2122,
+      "Ġinject": 2123,
+      "Ġinsu": 2124,
+      "Ġinfant": 2125,
+      "Ġinvol": 2126,
+      "ĠTow": 2127,
+      "ĠToo": 2128,
+      "ĠTom": 2129,
+      "ĠTry": 2130,
+      "ĠTol": 2131,
+      "ĠTwo": 2132,
+      "ĠTulip": 2133,
+      "ĠTennes": 2134,
+      "usions": 2135,
+      "lewood": 2136,
+      "atin": 2137,
+      "atter": 2138,
+      "atio": 2139,
+      "ataria": 2140,
+      "Ġbeat": 2141,
+      "Ġbeau": 2142,
+      "ooh": 2143,
+      "Ġhun": 2144,
+      "Ġhos": 2145,
+      "Ġhora": 2146,
+      "Ġholy": 2147,
+      "Ġhigh": 2148,
+      "ĠYa": 2149,
+      "ĠYep": 2150,
+      "ids": 2151,
+      "utif": 2152,
+      "Ġhavin": 2153,
+      "Ġhamburgers": 2154,
+      "Ġhallway": 2155,
+      "Ġdogs": 2156,
+      "Ġem": 2157,
+      "Ġeff": 2158,
+      "ĠMan": 2159,
+      "ĠMart": 2160,
+      "ĠMiss": 2161,
+      "ĠMotherfucker": 2162,
+      "ĠMIA": 2163,
+      "lding": 2164,
+      "ldren": 2165,
+      "ĠAl": 2166,
+      "ĠAt": 2167,
+      "ĠApples": 2168,
+      "ĠBea": 2169,
+      "ĠBoy": 2170,
+      "ĠBye": 2171,
+      "ĠBuddy": 2172,
+      "ĠBlessed": 2173,
+      "Ġisn": 2174,
+      "Ġisland": 2175,
+      "Ġfucking": 2176,
+      "Ġkiss": 2177,
+      "Ġkids": 2178,
+      "adies": 2179,
+      "Ġdont": 2180,
+      "amburgers": 2181,
+      "amoan": 2182,
+      "ĠHold": 2183,
+      "ĠHanoi": 2184,
+      "ĠHamburgers": 2185,
+      "riate": 2186,
+      "ĠNeg": 2187,
+      "ĠSlim": 2188,
+      "Ġwee": 2189,
+      "Ġweir": 2190,
+      "imp": 2191,
+      "ifs": 2192,
+      "ift": 2193,
+      "Ġstud": 2194,
+      "Ġstup": 2195,
+      "Ġstreet": 2196,
+      "Ġstarred": 2197,
+      "illa": 2198,
+      "entions": 2199,
+      "ĠDisco": 2200,
+      "Ġgold": 2201,
+      "Ġlight": 2202,
+      "Ġju": 2203,
+      "Ġjud": 2204,
+      "Ġknife": 2205,
+      "sters": 2206,
+      "Ġred": 2207,
+      "Ġrest": 2208,
+      "Ġreact": 2209,
+      "Ġreasonable": 2210,
+      "Ġforty": 2211,
+      "ustr": 2212,
+      "rol": 2213,
+      "Ġknows": 2214,
+      "ement": 2215,
+      "emember": 2216,
+      "empl": 2217,
+      "Ġwithout": 2218,
+      "Ġgets": 2219,
+      "see": 2220,
+      "seat": 2221,
+      "Ġupho": 2222,
+      "irt": 2223,
+      "hold": 2224,
+      "Ġnotice": 2225,
+      "ĠCho": 2226,
+      "ĠCoke": 2227,
+      "ĠCount": 2228,
+      "ĠCustomers": 2229,
+      "ĠCoffee": 2230,
+      "ĠGer": 2231,
+      "ĠGarcon": 2232,
+      "ĠGimp": 2233,
+      "ĠFirst": 2234,
+      "ĠFrench": 2235,
+      "ĠOoo": 2236,
+      "ĠOpen": 2237,
+      "ĠOui": 2238,
+      "Ġnose": 2239,
+      "ters": 2240,
+      "Ġbutter": 2241,
+      "ĠWere": 2242,
+      "ppin": 2243,
+      "ĠPr": 2244,
+      "ĠPot": 2245,
+      "ĠPut": 2246,
+      "ĠPep": 2247,
+      "ĠPerfect": 2248,
+      "ĠLe": 2249,
+      "ĠLake": 2250,
+      "ĠLance": 2251,
+      "ĠLew": 2252,
+      "ĠLike": 2253,
+      "rabbit": 2254,
+      "Ġwants": 2255,
+      "ĠRe": 2256,
+      "ĠRemember": 2257,
+      "Ġdec": 2258,
+      "ĠValley": 2259,
+      "ĠViet": 2260,
+      "Ġassho": 2261,
+      "thright": 2262,
+      "itty": 2263,
+      "itting": 2264,
+      "Ġoral": 2265,
+      "Ġwater": 2266,
+      "Ġwatched": 2267,
+      "Ġwatches": 2268,
+      "Ġsays": 2269,
+      "Ġgoodbye": 2270,
+      "Ġwhoa": 2271,
+      "Ġworried": 2272,
+      "Ġanyway": 2273,
+      "Ġanymore": 2274,
+      "ickly": 2275,
+      "Ġtalked": 2276,
+      "Ġcalls": 2277,
+      "Ġcallin": 2278,
+      "Ġplanned": 2279,
+      "ĠDonde": 2280,
+      "Ġsub": 2281,
+      "Ġwatching": 2282,
+      "peze": 2283,
+      "Ġblank": 2284,
+      "Ġcarry": 2285,
+      "Ġexpen": 2286,
+      "Ġexpl": 2287,
+      "ĠEl": 2288,
+      "ĠEsmarelda": 2289,
+      "Ġused": 2290,
+      "Ġsomewhere": 2291,
+      "ntil": 2292,
+      "ooties": 2293,
+      "Ġsaus": 2294,
+      "Ġquilt": 2295,
+      "Ġbackseat": 2296,
+      "Ġprod": 2297,
+      "Ġintentions": 2298,
+      "Ġride": 2299,
+      "Ġroom": 2300,
+      "umb": 2301,
+      "Ġroll": 2302,
+      "Ġcomfor": 2303,
+      "ations": 2304,
+      "ĠJulie": 2305,
+      "getarian": 2306,
+      "Ġfinder": 2307,
+      "Ġbite": 2308,
+      "Ġgrew": 2309,
+      "Ġfighter": 2310,
+      "Ġjoint": 2311,
+      "ĠGoddammit": 2312,
+      "apataria": 2313,
+      "istic": 2314,
+      "Ġpride": 2315,
+      "Ġprison": 2316,
+      "Ġprinci": 2317,
+      "Ġaskin": 2318,
+      "Ġasked": 2319,
+      "bean": 2320,
+      "ocki": 2321,
+      "Ġalright": 2322,
+      "Ġalong": 2323,
+      "Ġalmost": 2324,
+      "Ġspot": 2325,
+      "Ġspread": 2326,
+      "oxvill": 2327,
+      "weet": 2328,
+      "Ġkey": 2329,
+      "Ġkept": 2330,
+      "Ġthank": 2331,
+      "Ġlotsa": 2332,
+      "ĠLooks": 2333,
+      "Ġvisit": 2334,
+      "Ġtrans": 2335,
+      "Ġtraged": 2336,
+      "Ġtruly": 2337,
+      "Ġshare": 2338,
+      "Ġfriendly": 2339,
+      "Ġhelps": 2340,
+      "Ġeatin": 2341,
+      "ĠAmeric": 2342,
+      "Ġrealiz": 2343,
+      "ĠQue": 2344,
+      "Ġwaiting": 2345,
+      "Ġmornin": 2346,
+      "Ġcontrol": 2347,
+      "Ġcontempl": 2348,
+      "ĠCheck": 2349,
+      "Ġcleans": 2350,
+      "Ġbuyin": 2351,
+      "Ġfifth": 2352,
+      "Ġtomorrow": 2353,
+      "ĠStill": 2354,
+      "Ġunlo": 2355,
+      "Ġuncomfortable": 2356,
+      "Ġunfortunate": 2357,
+      "Ġrobbed": 2358,
+      "Ġkeeper": 2359,
+      "Ġapples": 2360,
+      "Ġapprop": 2361,
+      "Ġmadman": 2362,
+      "Ġmirror": 2363,
+      "Ġdirect": 2364,
+      "Ġgrandmother": 2365,
+      "Ġfeces": 2366,
+      "Ġfelt": 2367,
+      "Ġlaundry": 2368,
+      "Ġbellies": 2369,
+      "ava": 2370,
+      "love": 2371,
+      "perate": 2372,
+      "Ġfellas": 2373,
+      "Ġfactor": 2374,
+      "Ġclosed": 2375,
+      "Ġthoughts": 2376,
+      "Ġretired": 2377,
+      "ractive": 2378,
+      "ĠQuit": 2379,
+      "Ġwindows": 2380,
+      "Ġability": 2381,
+      "Ġwallet": 2382,
+      "Ġbullet": 2383,
+      "Ġdrivin": 2384,
+      "ĠWinocki": 2385,
+      "Ġperson": 2386,
+      "Ġhuh": 2387,
+      "Ġdollar": 2388,
+      "ĠMacDonal": 2389,
+      "ĠAnother": 2390,
+      "amps": 2391,
+      "ĠFuckin": 2392,
+      "ĠFabby": 2393,
+      "Ġtype": 2394,
+      "Ġbags": 2395,
+      "ording": 2396,
+      "Ġpriv": 2397,
+      "Ġpricks": 2398,
+      "ĠShit": 2399,
+      "Ġattractive": 2400,
+      "Ġshepherds": 2401,
+      "ummmm": 2402,
+      "resses": 2403,
+      "ressed": 2404,
+      "ĠMexico": 2405,
+      "ĠMexican": 2406,
+      "ĠMexicans": 2407,
+      "Ġdamned": 2408,
+      "Ġesta": 2409,
+      "Ġillusions": 2410,
+      "Ġillustr": 2411,
+      "Ġrace": 2412,
+      "Ġtwist": 2413,
+      "Ġtwenty": 2414,
+      "Ġslight": 2415,
+      "Ġslice": 2416,
+      "Ġbump": 2417,
+      "Ġmillionai": 2418,
+      "Ġchanged": 2419,
+      "Ġintervention": 2420,
+      "ĠThank": 2421,
+      "Ġbegins": 2422,
+      "Ġholding": 2423,
+      "ĠSprite": 2424,
+      "ĠSpanish": 2425,
+      "ificant": 2426,
+      "ifically": 2427,
+      "Ġanimals": 2428,
+      "ĠChill": 2429,
+      "ĠChrist": 2430,
+      "ĠKnoxvill": 2431,
+      "Ġspecialty": 2432,
+      "Ġchicken": 2433,
+      "Ġdivine": 2434,
+      "Ġpleasing": 2435,
+      "Ġ10": 2436,
+      "Ġzapataria": 2437,
+      "Ġentire": 2438,
+      "Ġentered": 2439,
+      "Ġacro": 2440,
+      "Ġsense": 2441,
+      "Ġsilence": 2442,
+      "Ġboth": 2443,
+      "Ġbottom": 2444,
+      "Ġmatter": 2445,
+      "Ġcheck": 2446,
+      "ĠTrudi": 2447,
+      "Ġeasy": 2448,
+      "Ġeasier": 2449,
+      "ĠBlood": 2450,
+      "ĠBlueberry": 2451,
+      "ĠDane": 2452,
+      "Ġresp": 2453,
+      "Ġnews": 2454,
+      "Ġsecret": 2455,
+      "Ġsecond": 2456,
+      "Ġsexy": 2457,
+      "Ġexpecting": 2458,
+      "Ġexpert": 2459,
+      "Ġexperien": 2460,
+      "ĠNothin": 2461,
+      "ĠNothing": 2462,
+      "Ġappreciate": 2463,
+      "Ġappreciated": 2464,
+      "Ġaccidentally": 2465,
+      "Ġimposs": 2466,
+      "Ġimport": 2467,
+      "Ġdangerous": 2468,
+      "merset": 2469,
+      "Ġvegetarian": 2470,
+      "Ġtrial": 2471,
+      "Ġartist": 2472,
+      "Ġbased": 2473,
+      "Ġbirthright": 2474,
+      "Ġdyin": 2475,
+      "Ġdinner": 2476,
+      "Ġgeneral": 2477,
+      "Ġgooks": 2478,
+      "Ġgangsters": 2479,
+      "Ġfingers": 2480,
+      "Ġcasa": 2481,
+      "Ġcross": 2482,
+      "Ġcircus": 2483,
+      "Ġnames": 2484,
+      "Ġpaid": 2485,
+      "Ġpossible": 2486,
+      "Ġinstead": 2487,
+      "Ġbecome": 2488,
+      "Ġhillbill": 2489,
+      "ĠMerci": 2490,
+      "Ġkickin": 2491,
+      "ĠSommerset": 2492,
+      "Ġrestaurants": 2493,
+      "ĠJackrabbit": 2494,
+      "ĠJewish": 2495,
+      "Ġmanager": 2496,
+      "ĠFonzie": 2497,
+      "ĠODing": 2498,
+      "ĠRespect": 2499,
+      "Ġexecute": 2500,
+      "Ġoffended": 2501,
+      "umpkin": 2502,
+      "Ġcompany": 2503,
+      "Ġcosts": 2504,
+      "Ġshotguns": 2505,
+      "Ġcounter": 2506,
+      "Ġprotective": 2507,
+      "Ġsplit": 2508,
+      "Ġspecifically": 2509,
+      "Ġcontinue": 2510,
+      "ĠMonroe": 2511,
+      "ĠHollywood": 2512,
+      "coup": 2513,
+      "lstery": 2514,
+      "namese": 2515,
+      "pital": 2516,
+      "Ġhate": 2517,
+      "Ġtrapeze": 2518,
+      "Ġtrophy": 2519,
+      "Ġturns": 2520,
+      "Ġwedding": 2521,
+      "Ġwoman": 2522,
+      "ĠInglewood": 2523,
+      "Ġscared": 2524,
+      "Ġsizes": 2525,
+      "Ġbrought": 2526,
+      "Ġbuilding": 2527,
+      "Ġdreadful": 2528,
+      "Ġcooperate": 2529,
+      "Ġcellular": 2530,
+      "Ġcrazy": 2531,
+      "Ġchildren": 2532,
+      "Ġconsider": 2533,
+      "Ġopinion": 2534,
+      "Ġtogether": 2535,
+      "Ġloyal": 2536,
+      "ĠWorld": 2537,
+      "Ġnervous": 2538,
+      "Ġpocket": 2539,
+      "Ġprepared": 2540,
+      "Ġthousand": 2541,
+      "Ġthreshold": 2542,
+      "Ġinjection": 2543,
+      "Ġinsured": 2544,
+      "ĠToluca": 2545,
+      "ĠTennessee": 2546,
+      "Ġbeaucoup": 2547,
+      "Ġhospital": 2548,
+      "utiful": 2549,
+      "ĠMartin": 2550,
+      "Ġstupid": 2551,
+      "Ġupholstery": 2552,
+      "ĠPepsi": 2553,
+      "ĠLewis": 2554,
+      "ĠVietnamese": 2555,
+      "Ġblankets": 2556,
+      "Ġexpensive": 2557,
+      "Ġexplos": 2558,
+      "Ġquilts": 2559,
+      "Ġtragedy": 2560,
+      "ĠAmerican": 2561,
+      "Ġcontemplating": 2562,
+      "Ġunload": 2563,
+      "Ġappropriate": 2564,
+      "Ġdirectly": 2565,
+      "ĠMacDonald": 2566,
+      "Ġmillionaires": 2567,
+      "ĠKnoxville": 2568,
+      "Ġhillbilly": 2569,
+      "!!": 2570,
+      "%.": 2571,
+      "'!": 2572,
+      "'-": 2573,
+      ".,": 2574,
+      "18": 2575,
+      "35": 2576,
+      "45": 2577,
+      "74": 2578,
+      "700": 2579,
+      "974": 2580,
+      ";,": 2581,
+      "?...": 2582,
+      "AR": 2583,
+      "AV": 2584,
+      "Bed": 2585,
+      "Bat": 2586,
+      "CE": 2587,
+      "CO": 2588,
+      "CT": 2589,
+      "Coy": 2590,
+      "Coolidge": 2591,
+      "Don": 2592,
+      "ER": 2593,
+      "Ever": 2594,
+      "Emp": 2595,
+      "FL": 2596,
+      "FO": 2597,
+      "Fraid": 2598,
+      "Good": 2599,
+      "Garcon": 2600,
+      "GUN": 2601,
+      "HE": 2602,
+      "Hoy": 2603,
+      "IV": 2604,
+      "It": 2605,
+      "ION": 2606,
+      "ICT": 2607,
+      "KUN": 2608,
+      "Luck": 2609,
+      "Mar": 2610,
+      "Marsellus": 2611,
+      "Member": 2612,
+      "Now": 2613,
+      "Neal": 2614,
+      "OR": 2615,
+      "OT": 2616,
+      "One": 2617,
+      "PS": 2618,
+      "PY": 2619,
+      "PER": 2620,
+      "RE": 2621,
+      "SU": 2622,
+      "Samoan": 2623,
+      "URE": 2624,
+      "We": 2625,
+      "af": 2626,
+      "aj": 2627,
+      "air": 2628,
+      "aven": 2629,
+      "aine": 2630,
+      "arett": 2631,
+      "ahit": 2632,
+      "autiful": 2633,
+      "bb": 2634,
+      "bl": 2635,
+      "bon": 2636,
+      "bar": 2637,
+      "bing": 2638,
+      "bat": 2639,
+      "but": 2640,
+      "ball": 2641,
+      "back": 2642,
+      "bly": 2643,
+      "bble": 2644,
+      "bos": 2645,
+      "best": 2646,
+      "bac": 2647,
+      "bies": 2648,
+      "bank": 2649,
+      "brow": 2650,
+      "blessed": 2651,
+      "bitty": 2652,
+      "che": 2653,
+      "cit": 2654,
+      "chat": 2655,
+      "can": 2656,
+      "cot": 2657,
+      "cat": 2658,
+      "cell": 2659,
+      "cil": 2660,
+      "cise": 2661,
+      "cony": 2662,
+      "cated": 2663,
+      "cident": 2664,
+      "cCoy": 2665,
+      "da": 2666,
+      "ds": 2667,
+      "ders": 2668,
+      "down": 2669,
+      "dest": 2670,
+      "dried": 2671,
+      "dressed": 2672,
+      "ex": 2673,
+      "ees": 2674,
+      "ear": 2675,
+      "egal": 2676,
+      "eather": 2677,
+      "ext": 2678,
+      "fe": 2679,
+      "fl": 2680,
+      "fu": 2681,
+      "fit": 2682,
+      "fis": 2683,
+      "fam": 2684,
+      "fie": 2685,
+      "friend": 2686,
+      "full": 2687,
+      "fire": 2688,
+      "fric": 2689,
+      "gr": 2690,
+      "gu": 2691,
+      "gy": 2692,
+      "gin": 2693,
+      "ges": 2694,
+      "gle": 2695,
+      "gie": 2696,
+      "gir": 2697,
+      "gag": 2698,
+      "gra": 2699,
+      "gth": 2700,
+      "ground": 2701,
+      "gical": 2702,
+      "ggs": 2703,
+      "gumm": 2704,
+      "ggest": 2705,
+      "hn": 2706,
+      "his": 2707,
+      "hing": 2708,
+      "hous": 2709,
+      "hng": 2710,
+      "iot": 2711,
+      "ior": 2712,
+      "ile": 2713,
+      "ild": 2714,
+      "ict": 2715,
+      "iod": 2716,
+      "iers": 2717,
+      "iqu": 2718,
+      "iac": 2719,
+      "iate": 2720,
+      "ives": 2721,
+      "iving": 2722,
+      "kes": 2723,
+      "know": 2724,
+      "lor": 2725,
+      "lve": 2726,
+      "lay": 2727,
+      "look": 2728,
+      "lop": 2729,
+      "light": 2730,
+      "lic": 2731,
+      "line": 2732,
+      "life": 2733,
+      "lady": 2734,
+      "ms": 2735,
+      "min": 2736,
+      "mer": 2737,
+      "mly": 2738,
+      "mick": 2739,
+      "mation": 2740,
+      "miss": 2741,
+      "mans": 2742,
+      "mel": 2743,
+      "milk": 2744,
+      "motherfucker": 2745,
+      "non": 2746,
+      "nout": 2747,
+      "nant": 2748,
+      "ners": 2749,
+      "night": 2750,
+      "num": 2751,
+      "nard": 2752,
+      "nough": 2753,
+      "niqu": 2754,
+      "oin": 2755,
+      "oor": 2756,
+      "oci": 2757,
+      "oice": 2758,
+      "ogs": 2759,
+      "ohh": 2760,
+      "oken": 2761,
+      "obos": 2762,
+      "ogra": 2763,
+      "ohn": 2764,
+      "ps": 2765,
+      "phe": 2766,
+      "pis": 2767,
+      "pes": 2768,
+      "par": 2769,
+      "pet": 2770,
+      "pal": 2771,
+      "pri": 2772,
+      "pse": 2773,
+      "pop": 2774,
+      "pos": 2775,
+      "pain": 2776,
+      "port": 2777,
+      "press": 2778,
+      "pread": 2779,
+      "pug": 2780,
+      "phic": 2781,
+      "ru": 2782,
+      "rit": 2783,
+      "rch": 2784,
+      "rant": 2785,
+      "rag": 2786,
+      "rass": 2787,
+      "rong": 2788,
+      "ration": 2789,
+      "rance": 2790,
+      "rup": 2791,
+      "rnie": 2792,
+      "rving": 2793,
+      "sw": 2794,
+      "sy": 2795,
+      "sed": 2796,
+      "sing": 2797,
+      "sell": 2798,
+      "sam": 2799,
+      "sent": 2800,
+      "sion": 2801,
+      "spe": 2802,
+      "sper": 2803,
+      "sible": 2804,
+      "sign": 2805,
+      "shit": 2806,
+      "spread": 2807,
+      "tu": 2808,
+      "tw": 2809,
+      "the": 2810,
+      "tin": 2811,
+      "ton": 2812,
+      "ted": 2813,
+      "tle": 2814,
+      "top": 2815,
+      "tra": 2816,
+      "tic": 2817,
+      "uu": 2818,
+      "uis": 2819,
+      "ues": 2820,
+      "ued": 2821,
+      "uro": 2822,
+      "uct": 2823,
+      "uate": 2824,
+      "undo": 2825,
+      "uhng": 2826,
+      "va": 2827,
+      "vy": 2828,
+      "val": 2829,
+      "war": 2830,
+      "wing": 2831,
+      "well": 2832,
+      "ware": 2833,
+      "word": 2834,
+      "yp": 2835,
+      "yer": 2836,
+      "yster": 2837,
+      "yze": 2838,
+      "yard": 2839,
+      "ybean": 2840,
+      "Ġ5": 2841,
+      "Ġice": 2842,
+      "Ġought": 2843,
+      "Ġround": 2844,
+      "Ġoun": 2845,
+      "Ġ700": 2846,
+      "Ġta": 2847,
+      "Ġtall": 2848,
+      "Ġtack": 2849,
+      "Ġtee": 2850,
+      "Ġtest": 2851,
+      "Ġtain": 2852,
+      "Ġtakes": 2853,
+      "Ġtaught": 2854,
+      "Ġtip": 2855,
+      "Ġtried": 2856,
+      "Ġtired": 2857,
+      "Ġtail": 2858,
+      "Ġtulip": 2859,
+      "hetic": 2860,
+      "oud": 2861,
+      "ouge": 2862,
+      "ougl": 2863,
+      "oufl": 2864,
+      "Ġack": 2865,
+      "Ġair": 2866,
+      "Ġable": 2867,
+      "Ġapt": 2868,
+      "Ġawhile": 2869,
+      "Ġaware": 2870,
+      "ina": 2871,
+      "ines": 2872,
+      "inct": 2873,
+      "Ġwake": 2874,
+      "Ġwol": 2875,
+      "Ġwide": 2876,
+      "Ġwhad": 2877,
+      "Ġwhit": 2878,
+      "Ġwhite": 2879,
+      "Ġwax": 2880,
+      "Ġwhether": 2881,
+      "Ġwild": 2882,
+      "ĠIndo": 2883,
+      "ĠIrving": 2884,
+      "Ġshat": 2885,
+      "Ġsing": 2886,
+      "Ġsuck": 2887,
+      "Ġsad": 2888,
+      "Ġsent": 2889,
+      "Ġsight": 2890,
+      "Ġsister": 2891,
+      "Ġsip": 2892,
+      "Ġsince": 2893,
+      "Ġsitting": 2894,
+      "Ġsweet": 2895,
+      "Ġsnout": 2896,
+      "rend": 2897,
+      "real": 2898,
+      "rest": 2899,
+      "react": 2900,
+      "ready": 2901,
+      "regar": 2902,
+      "ones": 2903,
+      "oned": 2904,
+      "onse": 2905,
+      "onun": 2906,
+      "onth": 2907,
+      "oniz": 2908,
+      "hall": 2909,
+      "hard": 2910,
+      "Ġyak": 2911,
+      "Ġbor": 2912,
+      "Ġbow": 2913,
+      "Ġbat": 2914,
+      "Ġbuck": 2915,
+      "Ġbri": 2916,
+      "Ġbust": 2917,
+      "Ġbod": 2918,
+      "Ġbother": 2919,
+      "Ġbour": 2920,
+      "Ġbark": 2921,
+      "Ġbold": 2922,
+      "Ġbins": 2923,
+      "Ġbreat": 2924,
+      "Ġbones": 2925,
+      "Ġmer": 2926,
+      "Ġmor": 2927,
+      "Ġmar": 2928,
+      "Ġmid": 2929,
+      "Ġmam": 2930,
+      "Ġmak": 2931,
+      "Ġmother": 2932,
+      "Ġmight": 2933,
+      "Ġmuse": 2934,
+      "Ġmain": 2935,
+      "Ġmap": 2936,
+      "Ġmush": 2937,
+      "Ġmilk": 2938,
+      "Ġmonth": 2939,
+      "Ġyoung": 2940,
+      "Ġtheat": 2941,
+      "Ġtheolo": 2942,
+      "Ġdet": 2943,
+      "Ġduck": 2944,
+      "Ġdom": 2945,
+      "Ġdut": 2946,
+      "Ġdro": 2947,
+      "Ġdem": 2948,
+      "Ġdea": 2949,
+      "Ġdra": 2950,
+      "Ġdies": 2951,
+      "Ġdue": 2952,
+      "Ġdren": 2953,
+      "Ġdaught": 2954,
+      "Ġdork": 2955,
+      "Ġdorks": 2956,
+      "Ġdumb": 2957,
+      "Ġdressed": 2958,
+      "Ġgor": 2959,
+      "Ġgim": 2960,
+      "Ġgig": 2961,
+      "Ġgame": 2962,
+      "Ġground": 2963,
+      "Ġglo": 2964,
+      "Ġgittin": 2965,
+      "Ġgyp": 2966,
+      "Ġfu": 2967,
+      "Ġfit": 2968,
+      "Ġfer": 2969,
+      "Ġfri": 2970,
+      "Ġfill": 2971,
+      "Ġfem": 2972,
+      "Ġfir": 2973,
+      "Ġfright": 2974,
+      "Ġfac": 2975,
+      "Ġfren": 2976,
+      "Ġfare": 2977,
+      "Ġfree": 2978,
+      "Ġfought": 2979,
+      "Ġfoll": 2980,
+      "Ġfles": 2981,
+      "Ġfried": 2982,
+      "Ġfunn": 2983,
+      "Ġfired": 2984,
+      "Ġfaster": 2985,
+      "Ġfurn": 2986,
+      "Ġfrench": 2987,
+      "erst": 2988,
+      "erations": 2989,
+      "ercise": 2990,
+      "eroin": 2991,
+      "ange": 2992,
+      "anilla": 2993,
+      "isp": 2994,
+      "ised": 2995,
+      "ished": 2996,
+      "Ġcet": 2997,
+      "Ġcut": 2998,
+      "Ġcal": 2999,
+      "Ġcam": 3000,
+      "Ġcook": 3001,
+      "Ġcig": 3002,
+      "Ġcour": 3003,
+      "Ġcol": 3004,
+      "Ġcred": 3005,
+      "Ġcav": 3006,
+      "Ġcrow": 3007,
+      "Ġcurt": 3008,
+      "Ġcustomers": 3009,
+      "Ġcaus": 3010,
+      "ndy": 3011,
+      "ndin": 3012,
+      "nderest": 3013,
+      "Ġoh": 3014,
+      "Ġocc": 3015,
+      "Ġoaf": 3016,
+      "Ġomel": 3017,
+      "Ġtoast": 3018,
+      "Ġtoday": 3019,
+      "Ġtobac": 3020,
+      "Ġtorch": 3021,
+      "otsa": 3022,
+      "otogra": 3023,
+      "Ġled": 3024,
+      "Ġlat": 3025,
+      "Ġlam": 3026,
+      "Ġlem": 3027,
+      "Ġlag": 3028,
+      "Ġlos": 3029,
+      "Ġlone": 3030,
+      "Ġlac": 3031,
+      "Ġline": 3032,
+      "Ġlend": 3033,
+      "Ġlue": 3034,
+      "Ġlaw": 3035,
+      "Ġladies": 3036,
+      "Ġlift": 3037,
+      "ĠWon": 3038,
+      "ĠWas": 3039,
+      "ĠWay": 3040,
+      "ĠWind": 3041,
+      "ĠWalk": 3042,
+      "ĠWait": 3043,
+      "ĠWipe": 3044,
+      "ĠWhether": 3045,
+      "ĠWrong": 3046,
+      "Ġnat": 3047,
+      "Ġnim": 3048,
+      "Ġnone": 3049,
+      "Ġnine": 3050,
+      "Ġnurs": 3051,
+      "Ġnuis": 3052,
+      "ckoned": 3053,
+      "Ġitty": 3054,
+      "ory": 3055,
+      "oran": 3056,
+      "orid": 3057,
+      "orth": 3058,
+      "orious": 3059,
+      "ortable": 3060,
+      "owder": 3061,
+      "Ġpit": 3062,
+      "Ġpet": 3063,
+      "Ġpad": 3064,
+      "Ġprou": 3065,
+      "Ġpul": 3066,
+      "Ġpee": 3067,
+      "Ġpool": 3068,
+      "Ġpain": 3069,
+      "Ġpap": 3070,
+      "Ġpist": 3071,
+      "Ġpants": 3072,
+      "Ġpec": 3073,
+      "Ġpuff": 3074,
+      "Ġpork": 3075,
+      "Ġpush": 3076,
+      "Ġpipe": 3077,
+      "Ġphase": 3078,
+      "Ġpitch": 3079,
+      "Ġpatio": 3080,
+      "Ġpooh": 3081,
+      "Ġpumpkin": 3082,
+      "Ġportable": 3083,
+      "Ġpowder": 3084,
+      "arue": 3085,
+      "arib": 3086,
+      "ete": 3087,
+      "etor": 3088,
+      "etch": 3089,
+      "etter": 3090,
+      "ette": 3091,
+      "Ġthin": 3092,
+      "Ġthro": 3093,
+      "Ġthick": 3094,
+      "Ġthirty": 3095,
+      "Ġthreat": 3096,
+      "Ġheaven": 3097,
+      "ens": 3098,
+      "enin": 3099,
+      "ening": 3100,
+      "enver": 3101,
+      "enge": 3102,
+      "ences": 3103,
+      "enhous": 3104,
+      "asy": 3105,
+      "asped": 3106,
+      "asphe": 3107,
+      "Ġincident": 3108,
+      "Ġinsign": 3109,
+      "eday": 3110,
+      "edie": 3111,
+      "ĠTho": 3112,
+      "ĠTime": 3113,
+      "ĠTold": 3114,
+      "ĠToss": 3115,
+      "ĠTonight": 3116,
+      "ĠTaster": 3117,
+      "ĠTHE": 3118,
+      "ĠTahit": 3119,
+      "ĠTues": 3120,
+      "ings": 3121,
+      "ingful": 3122,
+      "ingling": 3123,
+      "usive": 3124,
+      "usic": 3125,
+      "usboy": 3126,
+      "ussell": 3127,
+      "lear": 3128,
+      "leven": 3129,
+      "lehead": 3130,
+      "velop": 3131,
+      "veyard": 3132,
+      "ates": 3133,
+      "ative": 3134,
+      "atso": 3135,
+      "atisfied": 3136,
+      "atement": 3137,
+      "athetic": 3138,
+      "Ġbever": 3139,
+      "Ġbeautiful": 3140,
+      "ucklehead": 3141,
+      "oop": 3142,
+      "ooooh": 3143,
+      "Ġhot": 3144,
+      "Ġhom": 3145,
+      "Ġhop": 3146,
+      "Ġhide": 3147,
+      "Ġhum": 3148,
+      "Ġhittin": 3149,
+      "Ġhip": 3150,
+      "Ġhope": 3151,
+      "Ġhors": 3152,
+      "Ġhogs": 3153,
+      "Ġhyster": 3154,
+      "ĠYummy": 3155,
+      "Ġones": 3156,
+      "omin": 3157,
+      "ombies": 3158,
+      "ayne": 3159,
+      "ided": 3160,
+      "idence": 3161,
+      "Ġmelt": 3162,
+      "utal": 3163,
+      "ution": 3164,
+      "utta": 3165,
+      "elled": 3166,
+      "ellybean": 3167,
+      "alf": 3168,
+      "alif": 3169,
+      "alry": 3170,
+      "alib": 3171,
+      "alobos": 3172,
+      "alyze": 3173,
+      "Ġend": 3174,
+      "Ġeld": 3175,
+      "Ġears": 3176,
+      "Ġeight": 3177,
+      "Ġequ": 3178,
+      "Ġelem": 3179,
+      "Ġego": 3180,
+      "Ġeggs": 3181,
+      "Ġepis": 3182,
+      "ĠMad": 3183,
+      "ĠMam": 3184,
+      "ĠMag": 3185,
+      "ĠMake": 3186,
+      "ĠMind": 3187,
+      "ĠMum": 3188,
+      "ĠMuch": 3189,
+      "ĠMans": 3190,
+      "ĠMoun": 3191,
+      "ĠMilk": 3192,
+      "ĠMax": 3193,
+      "ĠMOT": 3194,
+      "ĠMaj": 3195,
+      "ĠMcCoy": 3196,
+      "ĠMedie": 3197,
+      "ĠMusic": 3198,
+      "ĠMalib": 3199,
+      "Ġshy": 3200,
+      "Ġshut": 3201,
+      "Ġshook": 3202,
+      "Ġshoe": 3203,
+      "Ġshift": 3204,
+      "Ġshirt": 3205,
+      "ldom": 3206,
+      "ĠAM": 3207,
+      "ĠAct": 3208,
+      "ĠAir": 3209,
+      "ĠAcc": 3210,
+      "ĠAside": 3211,
+      "ĠAsta": 3212,
+      "ĠAfric": 3213,
+      "ĠBell": 3214,
+      "ĠBad": 3215,
+      "ĠBust": 3216,
+      "ĠBars": 3217,
+      "ĠBox": 3218,
+      "ĠBank": 3219,
+      "ĠBaby": 3220,
+      "ĠBring": 3221,
+      "ĠBash": 3222,
+      "ĠBava": 3223,
+      "ĠBoran": 3224,
+      "ĠBetter": 3225,
+      "ĠBusboy": 3226,
+      "Ġfucks": 3227,
+      "Ġfucker": 3228,
+      "Ġkun": 3229,
+      "Ġkitty": 3230,
+      "Ġkooties": 3231,
+      "Ġketch": 3232,
+      "chniqu": 3233,
+      "ĠYoung": 3234,
+      "adin": 3235,
+      "ams": 3236,
+      "amora": 3237,
+      "amount": 3238,
+      "amundo": 3239,
+      "ĠHa": 3240,
+      "ĠHis": 3241,
+      "ĠHim": 3242,
+      "ĠHop": 3243,
+      "ĠHur": 3244,
+      "ĠHart": 3245,
+      "ĠHaw": 3246,
+      "ĠHard": 3247,
+      "ĠHang": 3248,
+      "ĠHope": 3249,
+      "ĠHoly": 3250,
+      "ĠHuhng": 3251,
+      "ĠHeroin": 3252,
+      "ĠHalf": 3253,
+      "ril": 3254,
+      "rip": 3255,
+      "rive": 3256,
+      "riage": 3257,
+      "rified": 3258,
+      "rigu": 3259,
+      "ĠNon": 3260,
+      "ĠNig": 3261,
+      "ĠNone": 3262,
+      "ĠNorm": 3263,
+      "ĠNormal": 3264,
+      "ĠNope": 3265,
+      "ĠNAV": 3266,
+      "ĠNext": 3267,
+      "ĠNorth": 3268,
+      "ĠSet": 3269,
+      "ĠSent": 3270,
+      "ĠSir": 3271,
+      "ĠSho": 3272,
+      "ĠSome": 3273,
+      "ĠSac": 3274,
+      "ĠSomet": 3275,
+      "ĠSue": 3276,
+      "ĠSound": 3277,
+      "ĠSli": 3278,
+      "ĠSleep": 3279,
+      "ĠSouth": 3280,
+      "ĠSaus": 3281,
+      "ĠSince": 3282,
+      "ĠSamoan": 3283,
+      "ĠSweet": 3284,
+      "ĠSPY": 3285,
+      "ĠScot": 3286,
+      "ĠSatisfied": 3287,
+      "Ġweight": 3288,
+      "Ġwashed": 3289,
+      "iment": 3290,
+      "imatin": 3291,
+      "imens": 3292,
+      "Ġwhatever": 3293,
+      "Ġsting": 3294,
+      "Ġstuck": 3295,
+      "Ġstall": 3296,
+      "Ġstand": 3297,
+      "Ġstren": 3298,
+      "Ġsteal": 3299,
+      "Ġstations": 3300,
+      "Ġstamps": 3301,
+      "Ġstrag": 3302,
+      "Ġstatement": 3303,
+      "ĠWhata": 3304,
+      "ĠWhatever": 3305,
+      "ĠWhatsam": 3306,
+      "Ġangry": 3307,
+      "Ġansw": 3308,
+      "ills": 3309,
+      "illing": 3310,
+      "illalobos": 3311,
+      "Ġuh": 3312,
+      "Ġuntil": 3313,
+      "Ġunderest": 3314,
+      "ents": 3315,
+      "ently": 3316,
+      "ĠDad": 3317,
+      "ĠDie": 3318,
+      "ĠDore": 3319,
+      "ĠDod": 3320,
+      "ĠDur": 3321,
+      "ĠDown": 3322,
+      "ĠDough": 3323,
+      "ĠDorks": 3324,
+      "ĠDougl": 3325,
+      "ĠDenver": 3326,
+      "Ġgodammit": 3327,
+      "Ġlip": 3328,
+      "ĠThem": 3329,
+      "Ġjack": 3330,
+      "Ġjoy": 3331,
+      "Ġjang": 3332,
+      "Ġjail": 3333,
+      "Ġjingling": 3334,
+      "Ġjellybean": 3335,
+      "store": 3336,
+      "story": 3337,
+      "stril": 3338,
+      "Ġrequ": 3339,
+      "Ġreach": 3340,
+      "Ġrepug": 3341,
+      "Ġreckoned": 3342,
+      "Ġgots": 3343,
+      "Ġforce": 3344,
+      "Ġforced": 3345,
+      "rod": 3346,
+      "ĠJody": 3347,
+      "ĠJohn": 3348,
+      "ĠJayne": 3349,
+      "Ġknown": 3350,
+      "Ġoutside": 3351,
+      "Ġoutfit": 3352,
+      "Ġnext": 3353,
+      "seas": 3354,
+      "selor": 3355,
+      "Ġmaniac": 3356,
+      "...!": 3357,
+      "...\"": 3358,
+      "...?": 3359,
+      "ction": 3360,
+      "ante": 3361,
+      "iring": 3362,
+      "irby": 3363,
+      "hod": 3364,
+      "ĠCall": 3365,
+      "ĠCop": 3366,
+      "ĠCol": 3367,
+      "ĠCap": 3368,
+      "ĠCary": 3369,
+      "ĠClim": 3370,
+      "ĠCoun": 3371,
+      "ĠCaine": 3372,
+      "ĠChall": 3373,
+      "ĠCarib": 3374,
+      "ĠClear": 3375,
+      "ĠComin": 3376,
+      "ooded": 3377,
+      "ĠGra": 3378,
+      "ĠGrand": 3379,
+      "ĠGentlemen": 3380,
+      "ĠGreat": 3381,
+      "ĠGiven": 3382,
+      "ĠGiving": 3383,
+      "ĠGrant": 3384,
+      "ags": 3385,
+      "ague": 3386,
+      "agull": 3387,
+      "ĠFU": 3388,
+      "ĠFil": 3389,
+      "ĠFore": 3390,
+      "ĠFight": 3391,
+      "ĠFoot": 3392,
+      "ĠFine": 3393,
+      "ĠFriend": 3394,
+      "ĠFox": 3395,
+      "ĠFeel": 3396,
+      "ĠFunny": 3397,
+      "ĠFederal": 3398,
+      "ĠFIV": 3399,
+      "ĠFOR": 3400,
+      "ĠFair": 3401,
+      "ĠFeather": 3402,
+      "ĠFrance": 3403,
+      "ĠFatso": 3404,
+      "ooka": 3405,
+      "ĠOF": 3406,
+      "ĠOf": 3407,
+      "ĠOr": 3408,
+      "ĠOak": 3409,
+      "ĠOutta": 3410,
+      "Ġnoise": 3411,
+      "Ġnostril": 3412,
+      "ilin": 3413,
+      "ilos": 3414,
+      "ilities": 3415,
+      "iliar": 3416,
+      "ilante": 3417,
+      "ophy": 3418,
+      "unk": 3419,
+      "unger": 3420,
+      "unken": 3421,
+      "unette": 3422,
+      "igs": 3423,
+      "igy": 3424,
+      "igilante": 3425,
+      "aks": 3426,
+      "acked": 3427,
+      "terfu": 3428,
+      "Ġseat": 3429,
+      "Ġseven": 3430,
+      "Ġsevent": 3431,
+      "Ġsewer": 3432,
+      "Ġseated": 3433,
+      "Ġsearch": 3434,
+      "Ġsepar": 3435,
+      "Ġsewing": 3436,
+      "Ġsendin": 3437,
+      "Ġseldom": 3438,
+      "Ġsection": 3439,
+      "Ġhers": 3440,
+      "oreans": 3441,
+      "ode": 3442,
+      "taurants": 3443,
+      "tably": 3444,
+      "essful": 3445,
+      "Ġbutton": 3446,
+      "Ġcannon": 3447,
+      "ĠWendy": 3448,
+      "pple": 3449,
+      "ĠAndy": 3450,
+      "ĠPie": 3451,
+      "ĠPack": 3452,
+      "ĠPitt": 3453,
+      "ĠPos": 3454,
+      "ĠPick": 3455,
+      "ĠPac": 3456,
+      "ĠPeople": 3457,
+      "ĠPhone": 3458,
+      "ĠPanda": 3459,
+      "ĠPeg": 3460,
+      "ĠPaul": 3461,
+      "ĠPork": 3462,
+      "ĠPush": 3463,
+      "ĠPhase": 3464,
+      "ĠPors": 3465,
+      "ĠPumpkin": 3466,
+      "ĠPICT": 3467,
+      "ĠPoor": 3468,
+      "ĠPigs": 3469,
+      "ighten": 3470,
+      "ural": 3471,
+      "urant": 3472,
+      "urren": 3473,
+      "ĠLos": 3474,
+      "ĠLaw": 3475,
+      "ĠListen": 3476,
+      "ĠLash": 3477,
+      "ĠLadies": 3478,
+      "ĠLava": 3479,
+      "ĠLotsa": 3480,
+      "ĠLarue": 3481,
+      "ĠLighten": 3482,
+      "ĠNova": 3483,
+      "ules": 3484,
+      "uliar": 3485,
+      "ĠRic": 3486,
+      "ĠRain": 3487,
+      "ĠRap": 3488,
+      "ĠRoll": 3489,
+      "ĠRouge": 3490,
+      "ĠRussell": 3491,
+      "Ġdevil": 3492,
+      "Ġdelic": 3493,
+      "Ġdevelop": 3494,
+      "ĠVan": 3495,
+      "ĠVery": 3496,
+      "ĠVillalobos": 3497,
+      "Ġhissy": 3498,
+      "Ġassoci": 3499,
+      "this": 3500,
+      "three": 3501,
+      "thirty": 3502,
+      "Ġorders": 3503,
+      "Ġorange": 3504,
+      "Ġthinking": 3505,
+      "Ġsoir": 3506,
+      "Ġsoak": 3507,
+      "Ġsolve": 3508,
+      "Ġsaying": 3509,
+      "oset": 3510,
+      "Ġ\"...": 3511,
+      "ically": 3512,
+      "icated": 3513,
+      "Ġmeanwhile": 3514,
+      "Ġmeaningful": 3515,
+      "ĠHear": 3516,
+      "Ġwhose": 3517,
+      "Ġworse": 3518,
+      "Ġtalks": 3519,
+      "Ġtalking": 3520,
+      "Ġplain": 3521,
+      "Ġplenty": 3522,
+      "Ġplug": 3523,
+      "Ġpliers": 3524,
+      "Ġplunger": 3525,
+      "oyees": 3526,
+      "Ġteller": 3527,
+      "Ġtelling": 3528,
+      "Ġsucc": 3529,
+      "Ġsuper": 3530,
+      "Ġsuggest": 3531,
+      "eech": 3532,
+      "olition": 3533,
+      "Ġblind": 3534,
+      "Ġblown": 3535,
+      "Ġblond": 3536,
+      "Ġblasphe": 3537,
+      "Ġcard": 3538,
+      "Ġcarried": 3539,
+      "Ġcarpet": 3540,
+      "esticated": 3541,
+      "Ġexcess": 3542,
+      "Ġexcuse": 3543,
+      "Ġexcit": 3544,
+      "Ġextra": 3545,
+      "Ġexercise": 3546,
+      "ĠThing": 3547,
+      "ĠThink": 3548,
+      "ĠThought": 3549,
+      "ĠThurs": 3550,
+      "Ġoffice": 3551,
+      "ĠEight": 3552,
+      "ĠEatin": 3553,
+      "ĠEnough": 3554,
+      "ĠErnie": 3555,
+      "ĠEuro": 3556,
+      "ĠEleven": 3557,
+      "Ġusually": 3558,
+      "Ġhowever": 3559,
+      "Ġneeded": 3560,
+      "acate": 3561,
+      "centration": 3562,
+      "centuate": 3563,
+      "Ġsail": 3564,
+      "Ġsaved": 3565,
+      "Ġsafe": 3566,
+      "Ġquit": 3567,
+      "Ġquick": 3568,
+      "Ġquiet": 3569,
+      "Ġquitting": 3570,
+      "Ġquickly": 3571,
+      "Ġqualif": 3572,
+      "Ġbackground": 3573,
+      "ĠJimmied": 3574,
+      "Ġbetcha": 3575,
+      "Ġprogr": 3576,
+      "Ġpropri": 3577,
+      "Ġprosper": 3578,
+      "Ġintend": 3579,
+      "Ġintrigu": 3580,
+      "Ġsometime": 3581,
+      "Ġhandy": 3582,
+      "Ġhanded": 3583,
+      "ĠUp": 3584,
+      "ĠUnder": 3585,
+      "ĠUntil": 3586,
+      "Ġrat": 3587,
+      "Ġrate": 3588,
+      "Ġration": 3589,
+      "Ġrud": 3590,
+      "Ġrags": 3591,
+      "Ġrules": 3592,
+      "Ġoverreact": 3593,
+      "Ġoverseas": 3594,
+      "Ġdeadli": 3595,
+      "geles": 3596,
+      "Ġroot": 3597,
+      "onto": 3598,
+      "Ġcompl": 3599,
+      "Ġcomfortable": 3600,
+      "Ġlean": 3601,
+      "Ġleast": 3602,
+      "Ġlegs": 3603,
+      "Ġleague": 3604,
+      "aude": 3605,
+      "lfriend": 3606,
+      "Ġbrake": 3607,
+      "Ġbrass": 3608,
+      "Ġbride": 3609,
+      "Ġbrutal": 3610,
+      "Ġbrunette": 3611,
+      "Ġmassaged": 3612,
+      "Ġdaylight": 3613,
+      "Ġcoke": 3614,
+      "Ġcobb": 3615,
+      "Ġload": 3616,
+      "Ġlose": 3617,
+      "Ġkills": 3618,
+      "Ġkilling": 3619,
+      "Ġremain": 3620,
+      "Ġremark": 3621,
+      "actly": 3622,
+      "Ġgrease": 3623,
+      "Ġgreenhous": 3624,
+      "Ġgreasy": 3625,
+      "cias": 3626,
+      "cile": 3627,
+      "ciation": 3628,
+      "ĠKing": 3629,
+      "ĠKoons": 3630,
+      "ĠKooties": 3631,
+      "ĠKilling": 3632,
+      "ĠKirby": 3633,
+      "ĠKoreans": 3634,
+      "Ġfights": 3635,
+      "Ġfightin": 3636,
+      "Ġfighting": 3637,
+      "Ġcoupl": 3638,
+      "ĠDoing": 3639,
+      "ĠDogs": 3640,
+      "Ġbigger": 3641,
+      "Ġbiggest": 3642,
+      "Ġbiggie": 3643,
+      "Ġdrag": 3644,
+      "Ġdrown": 3645,
+      "Ġdrug": 3646,
+      "Ġdrunken": 3647,
+      "Ġpronun": 3648,
+      "Ġpronto": 3649,
+      "becile": 3650,
+      "Ġaged": 3651,
+      "Ġagoniz": 3652,
+      "Ġagents": 3653,
+      "Ġalso": 3654,
+      "Ġalready": 3655,
+      "Ġspan": 3656,
+      "Ġspic": 3657,
+      "Ġsport": 3658,
+      "Ġspoons": 3659,
+      "Ġspider": 3660,
+      "Ġspurs": 3661,
+      "Ġspring": 3662,
+      "Ġspeech": 3663,
+      "Ġgunner": 3664,
+      "Ġhappening": 3665,
+      "weight": 3666,
+      "Ġlotta": 3667,
+      "ĠWhose": 3668,
+      "ĠWhopper": 3669,
+      "Ġhomeboy": 3670,
+      "ĠShepherd": 3671,
+      "ĠLookin": 3672,
+      "Ġrememberin": 3673,
+      "ccch": 3674,
+      "forty": 3675,
+      "formers": 3676,
+      "Ġvoll": 3677,
+      "Ġvict": 3678,
+      "Ġvoice": 3679,
+      "Ġvanilla": 3680,
+      "Ġvigilante": 3681,
+      "Ġvacate": 3682,
+      "Ġvaude": 3683,
+      "Ġtrue": 3684,
+      "Ġtradin": 3685,
+      "Ġtrunk": 3686,
+      "Ġwalks": 3687,
+      "Ġwalkin": 3688,
+      "Ġwalked": 3689,
+      "Ġwalking": 3690,
+      "Ġshame": 3691,
+      "Ġshakes": 3692,
+      "Ġshapes": 3693,
+      "respect": 3694,
+      "Ġbreaks": 3695,
+      "Ġmoves": 3696,
+      "Ġmoving": 3697,
+      "Ġfriends": 3698,
+      "Ġgoddammit": 3699,
+      "Ġboyfriend": 3700,
+      "Ġchit": 3701,
+      "Ġchamp": 3702,
+      "Ġchasing": 3703,
+      "Ġclear": 3704,
+      "ĠMary": 3705,
+      "ĠMarine": 3706,
+      "ĠMarines": 3707,
+      "ĠAmos": 3708,
+      "Ġrealistic": 3709,
+      "Ġforgets": 3710,
+      "Ġlovely": 3711,
+      "Ġdrinks": 3712,
+      "Ġagainst": 3713,
+      "Ġwaiter": 3714,
+      "Ġwaited": 3715,
+      "Ġwaitresses": 3716,
+      "Ġsmall": 3717,
+      "Ġsmother": 3718,
+      "Ġsmelled": 3719,
+      "Ġsmilin": 3720,
+      "Ġbooked": 3721,
+      "Ġbookies": 3722,
+      "Ġpiece": 3723,
+      "lemma": 3724,
+      "Ġstops": 3725,
+      "Ġstoppin": 3726,
+      "ĠChevy": 3727,
+      "ĠForty": 3728,
+      "Ġworkin": 3729,
+      "Ġeveryone": 3730,
+      "Ġeverybody": 3731,
+      "Ġcleaning": 3732,
+      "Ġcleaners": 3733,
+      "year": 3734,
+      "Ġminus": 3735,
+      "Ġmetal": 3736,
+      "Ġmethod": 3737,
+      "ĠStar": 3738,
+      "ĠStay": 3739,
+      "ĠStep": 3740,
+      "ĠStudi": 3741,
+      "ĠStrip": 3742,
+      "Ġunreal": 3743,
+      "Ġkeeping": 3744,
+      "Ġdiffer": 3745,
+      "Ġdiffers": 3746,
+      "Ġtastes": 3747,
+      "Ġappear": 3748,
+      "Ġaccording": 3749,
+      "Ġdied": 3750,
+      "Ġdilemma": 3751,
+      "Ġfeels": 3752,
+      "Ġputs": 3753,
+      "Ġputtin": 3754,
+      "Ġpopped": 3755,
+      "Ġbelong": 3756,
+      "Ġstorin": 3757,
+      "Ġstories": 3758,
+      "Ġstarts": 3759,
+      "Ġstarted": 3760,
+      "Ġstarting": 3761,
+      "Ġstartled": 3762,
+      "ĠGoodbye": 3763,
+      "like": 3764,
+      "livin": 3765,
+      "liquor": 3766,
+      "place": 3767,
+      "ployees": 3768,
+      "Ġidiot": 3769,
+      "Ġadmit": 3770,
+      "ĠIsland": 3771,
+      "onsib": 3772,
+      "Ġyear": 3773,
+      "Ġburnt": 3774,
+      "Ġburgers": 3775,
+      "Ġburned": 3776,
+      "Ġburden": 3777,
+      "Ġmindless": 3778,
+      "Ġguest": 3779,
+      "Ġgarden": 3780,
+      "Ġfella": 3781,
+      "Ġfellatio": 3782,
+      "Ġclit": 3783,
+      "Ġclock": 3784,
+      "Ġcloset": 3785,
+      "ĠWherever": 3786,
+      "Ġpoor": 3787,
+      "ĠYours": 3788,
+      "Ġretro": 3789,
+      "Ġretort": 3790,
+      "Ġretiring": 3791,
+      "Ġhandsome": 3792,
+      "ĠUnless": 3793,
+      "ĠUncomfortable": 3794,
+      "ĠUnfortunate": 3795,
+      "Ġbringin": 3796,
+      "Ġbringing": 3797,
+      "ĠQuack": 3798,
+      "ĠQuickly": 3799,
+      "ĠCheeseburgers": 3800,
+      "Ġtomatoes": 3801,
+      "Ġbelieved": 3802,
+      "eyball": 3803,
+      "pediment": 3804,
+      "Ġimmed": 3805,
+      "Ġimbecile": 3806,
+      "Ġimpediment": 3807,
+      "Ġteam": 3808,
+      "Ġtext": 3809,
+      "Ġtechniqu": 3810,
+      "Ġabuse": 3811,
+      "Ġabusive": 3812,
+      "Ġactress": 3813,
+      "Ġactually": 3814,
+      "Ġsleepin": 3815,
+      "ondo": 3816,
+      "Ġbedspread": 3817,
+      "Ġbullshit": 3818,
+      "Ġdried": 3819,
+      "Ġdriving": 3820,
+      "Ġgirlfriend": 3821,
+      "Ġowner": 3822,
+      "Ġowned": 3823,
+      "Ġpickin": 3824,
+      "Ġpicked": 3825,
+      "ards": 3826,
+      "Ġhuge": 3827,
+      "ĠAnwan": 3828,
+      "ĠAnswer": 3829,
+      "ĠAngeles": 3830,
+      "amples": 3831,
+      "Ġsticks": 3832,
+      "igners": 3833,
+      "ignated": 3834,
+      "ĠRockamora": 3835,
+      "Ġworldfam": 3836,
+      "ĠUhhh": 3837,
+      "Ġjobs": 3838,
+      "Ġlaughs": 3839,
+      "Ġlaughin": 3840,
+      "Ġ22": 3841,
+      "Ġencl": 3842,
+      "Ġengag": 3843,
+      "Ġtouched": 3844,
+      "Ġtaking": 3845,
+      "Ġsounds": 3846,
+      "Ġglad": 3847,
+      "Ġglance": 3848,
+      "Ġcares": 3849,
+      "Ġpercent": 3850,
+      "Ġperman": 3851,
+      "Ġperfect": 3852,
+      "Ġperiod": 3853,
+      "Ġpermiss": 3854,
+      "Ġperformers": 3855,
+      "Ġprice": 3856,
+      "Ġprices": 3857,
+      "Ġhurts": 3858,
+      "Ġearly": 3859,
+      "ĠMayonna": 3860,
+      "ĠMaynard": 3861,
+      "ĠAnybody": 3862,
+      "ĠAnyway": 3863,
+      "ĠAnything": 3864,
+      "ĠBeating": 3865,
+      "ĠShow": 3866,
+      "Ġstraw": 3867,
+      "ĠGotta": 3868,
+      "Ġattack": 3869,
+      "Ġshepherded": 3870,
+      "Ġwords": 3871,
+      "Ġbloodiest": 3872,
+      "ĠExpect": 3873,
+      "ĠExec": 3874,
+      "ĠExcuse": 3875,
+      "ĠExcell": 3876,
+      "ĠExactly": 3877,
+      "ĠExamples": 3878,
+      "Ġquestions": 3879,
+      "Ġchilly": 3880,
+      "chased": 3881,
+      "comes": 3882,
+      "Ġespress": 3883,
+      "Ġillegal": 3884,
+      "Ġrare": 3885,
+      "Ġraid": 3886,
+      "Ġraised": 3887,
+      "Ġtwice": 3888,
+      "Ġscore": 3889,
+      "Ġscour": 3890,
+      "Ġscary": 3891,
+      "Ġscamps": 3892,
+      "Ġscoop": 3893,
+      "Ġslope": 3894,
+      "Ġsymp": 3895,
+      "Ġsyrup": 3896,
+      "Ġservin": 3897,
+      "itional": 3898,
+      "Ġbums": 3899,
+      "Ġboxer": 3900,
+      "Ġdouble": 3901,
+      "Ġdisco": 3902,
+      "Ġdiscus": 3903,
+      "Ġdispos": 3904,
+      "Ġdisregar": 3905,
+      "Ġdisrespect": 3906,
+      "Ġdarker": 3907,
+      "Ġdreams": 3908,
+      "Ġfreakin": 3909,
+      "Ġfreaked": 3910,
+      "Ġcrisp": 3911,
+      "Ġcracked": 3912,
+      "Ġchoice": 3913,
+      "Ġchops": 3914,
+      "Ġchance": 3915,
+      "Ġchange": 3916,
+      "Ġchances": 3917,
+      "Ġlaying": 3918,
+      "Ġparts": 3919,
+      "Ġpartners": 3920,
+      "Ġintercom": 3921,
+      "Ġinterior": 3922,
+      "Ġinterru": 3923,
+      "Ġbegun": 3924,
+      "Ġhangin": 3925,
+      "ĠBurbank": 3926,
+      "ĠSpoken": 3927,
+      "Ġstayed": 3928,
+      "Ġregular": 3929,
+      "ĠChina": 3930,
+      "ĠFlock": 3931,
+      "ĠFlorid": 3932,
+      "tains": 3933,
+      "ĠRaven": 3934,
+      "ĠEverything": 3935,
+      "ĠKnock": 3936,
+      "ĠKnives": 3937,
+      "ĠKnucklehead": 3938,
+      "Ġcountin": 3939,
+      "Ġjokin": 3940,
+      "Ġjoking": 3941,
+      "Ġchicks": 3942,
+      "Ġtouchin": 3943,
+      "Ġtouching": 3944,
+      "Ġquestioned": 3945,
+      "ibility": 3946,
+      "many": 3947,
+      "Ġ100": 3948,
+      "Ġ1974": 3949,
+      "Ġzillion": 3950,
+      "Ġzombies": 3951,
+      "heads": 3952,
+      "Ġaccept": 3953,
+      "Ġaccentuate": 3954,
+      "Ġwinner": 3955,
+      "Ġskills": 3956,
+      "Ġsensu": 3957,
+      "Ġsensible": 3958,
+      "Ġsilver": 3959,
+      "Ġsilences": 3960,
+      "Ġsignificant": 3961,
+      "Ġsixty": 3962,
+      "Ġsixteen": 3963,
+      "Ġbeside": 3964,
+      "Ġmotion": 3965,
+      "Ġmatch": 3966,
+      "Ġmatches": 3967,
+      "Ġmarket": 3968,
+      "Ġdesignated": 3969,
+      "Ġforeigners": 3970,
+      "Ġchew": 3971,
+      "Ġcheese": 3972,
+      "Ġcampfire": 3973,
+      "Ġpositive": 3974,
+      "Ġheroin": 3975,
+      "ĠTruck": 3976,
+      "ĠTrust": 3977,
+      "Ġhidin": 3978,
+      "Ġmemory": 3979,
+      "ĠHolland": 3980,
+      "Ġwearin": 3981,
+      "Ġwashin": 3982,
+      "Ġstrippin": 3983,
+      "Ġrespect": 3984,
+      "Ġresidence": 3985,
+      "Ġreader": 3986,
+      "Ġforgot": 3987,
+      "Ġforgive": 3988,
+      "Ġforgittin": 3989,
+      "Ġforgiven": 3990,
+      "ĠRedline": 3991,
+      "ĠRedondo": 3992,
+      "Ġringing": 3993,
+      "Ġcharmin": 3994,
+      "Ġdifferences": 3995,
+      "Ġpointed": 3996,
+      "Ġtelevis": 3997,
+      "Ġmoments": 3998,
+      "Ġseriously": 3999,
+      "aiian": 4000,
+      "clock": 4001,
+      "cloud": 4002,
+      "ofa": 4003,
+      "villian": 4004,
+      "Ġvehic": 4005,
+      "Ġrib": 4006,
+      "Ġrich": 4007,
+      "Ġrice": 4008,
+      "Ġtrippin": 4009,
+      "Ġarrive": 4010,
+      "Ġyella": 4011,
+      "Ġbasically": 4012,
+      "Ġbroke": 4013,
+      "Ġbroad": 4014,
+      "Ġbroken": 4015,
+      "Ġbirds": 4016,
+      "Ġmessy": 4017,
+      "Ġmouths": 4018,
+      "Ġdysent": 4019,
+      "Ġdiners": 4020,
+      "Ġgenerations": 4021,
+      "Ġgrab": 4022,
+      "Ġgraveyard": 4023,
+      "Ġgracias": 4024,
+      "Ġgangsta": 4025,
+      "Ġflat": 4026,
+      "Ġflies": 4027,
+      "Ġflavor": 4028,
+      "Ġfinger": 4029,
+      "Ġfoxy": 4030,
+      "Ġfoundation": 4031,
+      "Ġfinishing": 4032,
+      "ervation": 4033,
+      "Ġcash": 4034,
+      "Ġcroaks": 4035,
+      "Ġcircle": 4036,
+      "Ġcaptu": 4037,
+      "Ġcorrectly": 4038,
+      "Ġcertainly": 4039,
+      "Ġtossed": 4040,
+      "ĠWarmer": 4041,
+      "ĠWillis": 4042,
+      "Ġnamed": 4043,
+      "Ġpair": 4044,
+      "Ġpigs": 4045,
+      "Ġpacks": 4046,
+      "Ġpunchy": 4047,
+      "Ġpissed": 4048,
+      "Ġpossess": 4049,
+      "Ġthrowing": 4050,
+      "Ġinstinct": 4051,
+      "Ġbecame": 4052,
+      "Ġhours": 4053,
+      "Ġeyebrow": 4054,
+      "ĠMerde": 4055,
+      "Ġshoppin": 4056,
+      "Ġkicks": 4057,
+      "ĠSeven": 4058,
+      "ĠSearch": 4059,
+      "ĠSeagull": 4060,
+      "ĠSomeday": 4061,
+      "Ġstabbing": 4062,
+      "Ġrestaurant": 4063,
+      "ĠJews": 4064,
+      "Ġmanagers": 4065,
+      "ĠFonzies": 4066,
+      "ĠODin": 4067,
+      "ĠOnly": 4068,
+      "ĠRestaurants": 4069,
+      "Ġplayed": 4070,
+      "Ġexecution": 4071,
+      "Ġinterested": 4072,
+      "Ġinteresting": 4073,
+      "ĠUuummmm": 4074,
+      "ĠUuuu": 4075,
+      "ĠUuccch": 4076,
+      "Ġrisky": 4077,
+      "umpy": 4078,
+      "Ġcomprend": 4079,
+      "Ġleader": 4080,
+      "Ġcoldbl": 4081,
+      "Ġcollected": 4082,
+      "Ġcounselor": 4083,
+      "Ġprotecting": 4084,
+      "Ġsplatter": 4085,
+      "Ġspecimens": 4086,
+      "Ġcontinued": 4087,
+      "Ġadventures": 4088,
+      "Ġdriveway": 4089,
+      "ĠMonroes": 4090,
+      "Ġdelivering": 4091,
+      "ONE": 4092,
+      "doings": 4093,
+      "glers": 4094,
+      "ledge": 4095,
+      "nowledge": 4096,
+      "short": 4097,
+      "shirt": 4098,
+      "Ġ818": 4099,
+      "Ġticking": 4100,
+      "Ġtickle": 4101,
+      "Ġtender": 4102,
+      "Ġwetback": 4103,
+      "Ġswine": 4104,
+      "Ġswitch": 4105,
+      "Ġsatisfied": 4106,
+      "Ġseller": 4107,
+      "Ġboil": 4108,
+      "Ġboards": 4109,
+      "Ġbuilt": 4110,
+      "Ġbubble": 4111,
+      "Ġbleu": 4112,
+      "Ġblew": 4113,
+      "Ġbald": 4114,
+      "Ġbalcony": 4115,
+      "Ġmissed": 4116,
+      "Ġdryin": 4117,
+      "Ġdicks": 4118,
+      "Ġdickless": 4119,
+      "Ġgrasped": 4120,
+      "Ġgrumpy": 4121,
+      "Ġfuture": 4122,
+      "Ġfutility": 4123,
+      "Ġfamily": 4124,
+      "Ġfamiliar": 4125,
+      "Ġfixed": 4126,
+      "Ġfireplace": 4127,
+      "Ġconfis": 4128,
+      "Ġconcentration": 4129,
+      "Ġcorny": 4130,
+      "Ġcorpse": 4131,
+      "Ġcowboy": 4132,
+      "Ġcowgir": 4133,
+      "Ġcornerst": 4134,
+      "Ġodds": 4135,
+      "Ġlawn": 4136,
+      "Ġlazy": 4137,
+      "Ġnipples": 4138,
+      "Ġnipple": 4139,
+      "Ġnutrit": 4140,
+      "Ġphotogra": 4141,
+      "Ġphilos": 4142,
+      "Ġparalyze": 4143,
+      "Ġparamount": 4144,
+      "Ġpencil": 4145,
+      "Ġpalms": 4146,
+      "Ġpalooka": 4147,
+      "Ġpurse": 4148,
+      "Ġpurchased": 4149,
+      "Ġpulling": 4150,
+      "Ġpresent": 4151,
+      "Ġpreservation": 4152,
+      "Ġinformed": 4153,
+      "Ġinformation": 4154,
+      "Ġinvolve": 4155,
+      "Ġinvolved": 4156,
+      "ĠTowel": 4157,
+      "ĠTrying": 4158,
+      "Ġhunk": 4159,
+      "Ġhungry": 4160,
+      "Ġholyies": 4161,
+      "Ġholyiest": 4162,
+      "Ġhighs": 4163,
+      "Ġembar": 4164,
+      "Ġemployees": 4165,
+      "Ġeffect": 4166,
+      "Ġeffort": 4167,
+      "ĠMissus": 4168,
+      "ĠAlso": 4169,
+      "ĠAlmost": 4170,
+      "ĠBeach": 4171,
+      "ĠBeautiful": 4172,
+      "ĠBoys": 4173,
+      "ĠNegro": 4174,
+      "ĠNegative": 4175,
+      "Ġweek": 4176,
+      "Ġweeks": 4177,
+      "Ġweirdo": 4178,
+      "Ġweirdest": 4179,
+      "Ġlights": 4180,
+      "Ġjury": 4181,
+      "Ġjuice": 4182,
+      "Ġjudge": 4183,
+      "Ġjudging": 4184,
+      "Ġreaction": 4185,
+      "ĠChoice": 4186,
+      "ĠChoco": 4187,
+      "ĠCounting": 4188,
+      "ĠGermans": 4189,
+      "ĠGermany": 4190,
+      "ĠOooohh": 4191,
+      "ĠOooooooh": 4192,
+      "Ġbutterin": 4193,
+      "Ġbuttermilk": 4194,
+      "ĠPride": 4195,
+      "ĠPromise": 4196,
+      "ĠReally": 4197,
+      "ĠReady": 4198,
+      "Ġdecide": 4199,
+      "Ġdecided": 4200,
+      "Ġasshole": 4201,
+      "Ġassholes": 4202,
+      "Ġsubject": 4203,
+      "Ġsubterfu": 4204,
+      "ĠElmo": 4205,
+      "ĠElvis": 4206,
+      "Ġsausage": 4207,
+      "Ġsausages": 4208,
+      "Ġproduct": 4209,
+      "Ġprodigy": 4210,
+      "umbian": 4211,
+      "Ġcomforters": 4212,
+      "Ġcomfortably": 4213,
+      "Ġprinciple": 4214,
+      "Ġprincipal": 4215,
+      "Ġkeys": 4216,
+      "Ġkeyed": 4217,
+      "Ġthanked": 4218,
+      "Ġvisitor": 4219,
+      "Ġtransport": 4220,
+      "Ġtransitional": 4221,
+      "Ġrealize": 4222,
+      "Ġrealization": 4223,
+      "Ġcleansers": 4224,
+      "Ġprivate": 4225,
+      "Ġprivile": 4226,
+      "Ġillustrate": 4227,
+      "Ġillustrating": 4228,
+      "Ġslightly": 4229,
+      "Ġacross": 4230,
+      "Ġacrobat": 4231,
+      "Ġbottoms": 4232,
+      "Ġchecking": 4233,
+      "ĠBloody": 4234,
+      "Ġresponse": 4235,
+      "Ġresponsib": 4236,
+      "Ġexperience": 4237,
+      "Ġexperienced": 4238,
+      "Ġimpossible": 4239,
+      "Ġimpossibility": 4240,
+      "Ġimportant": 4241,
+      "Ġimportance": 4242,
+      "Ġcrossin": 4243,
+      "Ġloyalty": 4244,
+      "Ġexplosive": 4245,
+      "Ġexplosions": 4246,
+      "Ġunloads": 4247,
+      "357": 4248,
+      "ARONE": 4249,
+      "Bedside": 4250,
+      "Baton": 4251,
+      "COPS": 4252,
+      "Empty": 4253,
+      "FLY": 4254,
+      "FOX": 4255,
+      "Goodnight": 4256,
+      "GUNS": 4257,
+      "Hoyle": 4258,
+      "KUNG": 4259,
+      "Lucky": 4260,
+      "Marvin": 4261,
+      "PERFLY": 4262,
+      "SUPERFLY": 4263,
+      "arettes": 4264,
+      "butt": 4265,
+      "field": 4266,
+      "fully": 4267,
+      "gummers": 4268,
+      "iately": 4269,
+      "layin": 4270,
+      "poppin": 4271,
+      "rassed": 4272,
+      "speak": 4273,
+      "twenty": 4274,
+      "warm": 4275,
+      "Ġoughta": 4276,
+      "Ġounce": 4277,
+      "Ġ7000": 4278,
+      "Ġtacks": 4279,
+      "Ġtainted": 4280,
+      "ouflage": 4281,
+      "Ġacknowledge": 4282,
+      "Ġwolves": 4283,
+      "Ġwhadda": 4284,
+      "Ġwhites": 4285,
+      "Ġshatter": 4286,
+      "Ġsingle": 4287,
+      "Ġsuckin": 4288,
+      "Ġsweetie": 4289,
+      "Ġboring": 4290,
+      "Ġbowl": 4291,
+      "Ġbattle": 4292,
+      "Ġbrim": 4293,
+      "Ġbodies": 4294,
+      "Ġbothering": 4295,
+      "Ġbourbon": 4296,
+      "Ġbarkin": 4297,
+      "Ġbreathe": 4298,
+      "Ġmerit": 4299,
+      "Ġmoral": 4300,
+      "Ġmarriage": 4301,
+      "Ġmidst": 4302,
+      "Ġmama": 4303,
+      "Ġmakin": 4304,
+      "Ġmuseum": 4305,
+      "Ġmaintain": 4306,
+      "Ġmaple": 4307,
+      "Ġmushroom": 4308,
+      "Ġmonths": 4309,
+      "Ġtheatre": 4310,
+      "Ġtheological": 4311,
+      "Ġdetail": 4312,
+      "Ġdomesticated": 4313,
+      "Ġduty": 4314,
+      "Ġdrove": 4315,
+      "Ġdemolition": 4316,
+      "Ġdeaf": 4317,
+      "Ġdrawer": 4318,
+      "Ġdrenched": 4319,
+      "Ġdaughter": 4320,
+      "Ġdorky": 4321,
+      "Ġgorilla": 4322,
+      "Ġgimmick": 4323,
+      "Ġgiggle": 4324,
+      "Ġgloves": 4325,
+      "Ġfries": 4326,
+      "Ġfilled": 4327,
+      "Ġfemale": 4328,
+      "Ġfirmly": 4329,
+      "Ġfrightening": 4330,
+      "Ġfacing": 4331,
+      "Ġfrenzy": 4332,
+      "Ġfreeze": 4333,
+      "Ġfollow": 4334,
+      "Ġflesh": 4335,
+      "Ġfunniest": 4336,
+      "Ġfurnished": 4337,
+      "Ġceta": 4338,
+      "Ġcalm": 4339,
+      "Ġcamouflage": 4340,
+      "Ġcigarettes": 4341,
+      "Ġcourt": 4342,
+      "Ġcola": 4343,
+      "Ġcredit": 4344,
+      "Ġcavalry": 4345,
+      "Ġcrowd": 4346,
+      "Ġcausing": 4347,
+      "Ġoccurren": 4348,
+      "Ġoafish": 4349,
+      "Ġomelet": 4350,
+      "Ġtoasted": 4351,
+      "Ġtobacco": 4352,
+      "Ġlater": 4353,
+      "Ġlamb": 4354,
+      "Ġlemon": 4355,
+      "Ġlagging": 4356,
+      "Ġlosin": 4357,
+      "Ġlonely": 4358,
+      "Ġlaced": 4359,
+      "Ġluego": 4360,
+      "Ġlawyer": 4361,
+      "ĠWindex": 4362,
+      "ĠWalker": 4363,
+      "ĠWaitresses": 4364,
+      "Ġnatural": 4365,
+      "Ġnimrod": 4366,
+      "Ġnurses": 4367,
+      "Ġnuisance": 4368,
+      "Ġpetrified": 4369,
+      "Ġproud": 4370,
+      "Ġpulse": 4371,
+      "Ġpools": 4372,
+      "Ġpainful": 4373,
+      "Ġpaper": 4374,
+      "Ġpistol": 4375,
+      "Ġpeculiar": 4376,
+      "Ġpuffin": 4377,
+      "Ġthroat": 4378,
+      "Ġthicker": 4379,
+      "Ġthreatenin": 4380,
+      "Ġinsignificant": 4381,
+      "ĠThose": 4382,
+      "ĠTasters": 4383,
+      "ĠTahiti": 4384,
+      "ĠTuesday": 4385,
+      "Ġbeverage": 4386,
+      "Ġhomes": 4387,
+      "Ġhumor": 4388,
+      "Ġhips": 4389,
+      "Ġhorses": 4390,
+      "Ġhysterical": 4391,
+      "Ġmelted": 4392,
+      "Ġelders": 4393,
+      "Ġequally": 4394,
+      "Ġelement": 4395,
+      "Ġepisode": 4396,
+      "ĠMadonna": 4397,
+      "ĠMamie": 4398,
+      "ĠMagnum": 4399,
+      "ĠMucho": 4400,
+      "ĠMansfield": 4401,
+      "ĠMountains": 4402,
+      "ĠMaxie": 4403,
+      "ĠMOTION": 4404,
+      "ĠMajor": 4405,
+      "ĠMedieval": 4406,
+      "ĠMalibu": 4407,
+      "ĠActually": 4408,
+      "ĠAccording": 4409,
+      "ĠAfrican": 4410,
+      "ĠBuster": 4411,
+      "ĠBanks": 4412,
+      "ĠBashful": 4413,
+      "ĠBusboys": 4414,
+      "Ġkung": 4415,
+      "Ġketchup": 4416,
+      "ĠHurry": 4417,
+      "ĠHartz": 4418,
+      "ĠHawaiian": 4419,
+      "ĠHopefully": 4420,
+      "ĠNigger": 4421,
+      "ĠNormally": 4422,
+      "ĠNAVARONE": 4423,
+      "ĠSirk": 4424,
+      "ĠShoot": 4425,
+      "ĠSacre": 4426,
+      "ĠSomething": 4427,
+      "ĠSounds": 4428,
+      "ĠSlip": 4429,
+      "ĠSausages": 4430,
+      "ĠScotty": 4431,
+      "Ġstrength": 4432,
+      "Ġstealin": 4433,
+      "Ġstragglers": 4434,
+      "ĠWhatsamatter": 4435,
+      "Ġanswers": 4436,
+      "Ġunderestimatin": 4437,
+      "ĠDoren": 4438,
+      "ĠDodge": 4439,
+      "ĠDurwood": 4440,
+      "ĠDoughboy": 4441,
+      "ĠDouglas": 4442,
+      "Ġjoypoppin": 4443,
+      "Ġjangling": 4444,
+      "Ġjailhouse": 4445,
+      "stores": 4446,
+      "Ġrequest": 4447,
+      "Ġrepugnant": 4448,
+      "Ġoutfits": 4449,
+      "ĠCops": 4450,
+      "ĠColumbian": 4451,
+      "ĠCapt": 4452,
+      "ĠClimb": 4453,
+      "ĠCounty": 4454,
+      "ĠChallenge": 4455,
+      "ĠCaribbean": 4456,
+      "ĠGrace": 4457,
+      "ĠGrandpa": 4458,
+      "ĠFilters": 4459,
+      "ĠForever": 4460,
+      "ĠFIVE": 4461,
+      "ĠFORCE": 4462,
+      "Ġseventies": 4463,
+      "Ġseparation": 4464,
+      "ĠPositive": 4465,
+      "ĠPacific": 4466,
+      "ĠPeggy": 4467,
+      "ĠPorsche": 4468,
+      "ĠPICTURE": 4469,
+      "ĠLaws": 4470,
+      "ĠRichard": 4471,
+      "ĠRapist": 4472,
+      "ĠRollin": 4473,
+      "Ġdelicate": 4474,
+      "Ġdeveloped": 4475,
+      "Ġassociates": 4476,
+      "Ġpluggin": 4477,
+      "Ġsuccessful": 4478,
+      "Ġblonde": 4479,
+      "Ġblaspheme": 4480,
+      "Ġexcessive": 4481,
+      "Ġexciting": 4482,
+      "ĠThursday": 4483,
+      "ĠEurope": 4484,
+      "Ġqualifies": 4485,
+      "Ġprograms": 4486,
+      "Ġproprietor": 4487,
+      "Ġprosperous": 4488,
+      "Ġintriguing": 4489,
+      "Ġrationale": 4490,
+      "Ġrude": 4491,
+      "Ġoverreacted": 4492,
+      "Ġdeadliest": 4493,
+      "Ġcomplete": 4494,
+      "Ġgreenhouses": 4495,
+      "Ġpronunciation": 4496,
+      "Ġagonizing": 4497,
+      "Ġvolleyball": 4498,
+      "Ġvictorious": 4499,
+      "Ġvaudevillian": 4500,
+      "Ġchampion": 4501,
+      "ĠStudios": 4502,
+      "Ġunrealistic": 4503,
+      "Ġadmits": 4504,
+      "ĠUnfortunately": 4505,
+      "Ġimmediately": 4506,
+      "Ġtechnique": 4507,
+      "Ġbedspreads": 4508,
+      "Ġworldfamous": 4509,
+      "Ġenclosed": 4510,
+      "Ġengagement": 4511,
+      "Ġpermanently": 4512,
+      "Ġperfectly": 4513,
+      "Ġpermission": 4514,
+      "ĠMayonnaise": 4515,
+      "ĠExecute": 4516,
+      "ĠExcellent": 4517,
+      "Ġespresso": 4518,
+      "Ġslopeheads": 4519,
+      "Ġsympathetic": 4520,
+      "Ġdiscussion": 4521,
+      "Ġdisposing": 4522,
+      "Ġdisregard": 4523,
+      "Ġinterrupt": 4524,
+      "Ġregularly": 4525,
+      "ĠFlorida": 4526,
+      "Ġaccepted": 4527,
+      "Ġsensual": 4528,
+      "Ġtelevision": 4529,
+      "Ġvehicle": 4530,
+      "Ġdysentery": 4531,
+      "Ġcaptured": 4532,
+      "ĠSearching": 4533,
+      "ĠSeagulls": 4534,
+      "ĠUuuuummmm": 4535,
+      "Ġcomprende": 4536,
+      "Ġcoldblooded": 4537,
+      "Ġconfiscated": 4538,
+      "Ġcowgirl": 4539,
+      "Ġcornerstone": 4540,
+      "Ġnutritious": 4541,
+      "Ġphotographic": 4542,
+      "Ġphilosophy": 4543,
+      "Ġpencils": 4544,
+      "Ġembarrassed": 4545,
+      "ĠOooohhhh": 4546,
+      "Ġsubterfuge": 4547,
+      "Ġproducts": 4548,
+      "Ġprincipals": 4549,
+      "Ġprivileges": 4550,
+      "Ġresponsibilities": 4551,
+      "Ġoccurrence": 4552
+    },
+    "merges": [
+      [
+        "Ġ",
+        "t"
+      ],
+      [
+        "h",
+        "e"
+      ],
+      [
+        "o",
+        "u"
+      ],
+      [
+        "Ġ",
+        "a"
+      ],
+      [
+        "i",
+        "n"
+      ],
+      [
+        "Ġ",
+        "w"
+      ],
+      [
+        "Ġ",
+        "I"
+      ],
+      [
+        "Ġ",
+        "s"
+      ],
+      [
+        "r",
+        "e"
+      ],
+      [
+        "o",
+        "n"
+      ],
+      [
+        "h",
+        "a"
+      ],
+      [
+        "Ġ",
+        "y"
+      ],
+      [
+        "i",
+        "t"
+      ],
+      [
+        "Ġ",
+        "b"
+      ],
+      [
+        "Ġ",
+        "m"
+      ],
+      [
+        "Ġy",
+        "ou"
+      ],
+      [
+        "Ġt",
+        "he"
+      ],
+      [
+        "Ġ",
+        "d"
+      ],
+      [
+        "Ġ",
+        "g"
+      ],
+      [
+        "Ġ",
+        "f"
+      ],
+      [
+        "l",
+        "l"
+      ],
+      [
+        "e",
+        "r"
+      ],
+      [
+        "ha",
+        "t"
+      ],
+      [
+        "a",
+        "n"
+      ],
+      [
+        "i",
+        "s"
+      ],
+      [
+        "Ġ",
+        "c"
+      ],
+      [
+        "'",
+        "s"
+      ],
+      [
+        "n",
+        "d"
+      ],
+      [
+        "Ġ",
+        "o"
+      ],
+      [
+        "e",
+        "s"
+      ],
+      [
+        "Ġt",
+        "o"
+      ],
+      [
+        "o",
+        "t"
+      ],
+      [
+        "Ġ",
+        "l"
+      ],
+      [
+        "Ġ",
+        "W"
+      ],
+      [
+        "Ġ",
+        "n"
+      ],
+      [
+        "c",
+        "k"
+      ],
+      [
+        "Ġ",
+        "it"
+      ],
+      [
+        "o",
+        "r"
+      ],
+      [
+        "o",
+        "w"
+      ],
+      [
+        "Ġ",
+        "p"
+      ],
+      [
+        "'",
+        "t"
+      ],
+      [
+        "a",
+        "r"
+      ],
+      [
+        "e",
+        "t"
+      ],
+      [
+        "Ġt",
+        "h"
+      ],
+      [
+        "Ġ",
+        "he"
+      ],
+      [
+        "e",
+        "n"
+      ],
+      [
+        "a",
+        "s"
+      ],
+      [
+        "Ġ",
+        "in"
+      ],
+      [
+        "e",
+        "d"
+      ],
+      [
+        "Ġ",
+        "T"
+      ],
+      [
+        "in",
+        "g"
+      ],
+      [
+        "Ġo",
+        "f"
+      ],
+      [
+        "u",
+        "s"
+      ],
+      [
+        "l",
+        "e"
+      ],
+      [
+        "v",
+        "e"
+      ],
+      [
+        "a",
+        "t"
+      ],
+      [
+        "Ġb",
+        "e"
+      ],
+      [
+        "Ġa",
+        "nd"
+      ],
+      [
+        "u",
+        "ck"
+      ],
+      [
+        "o",
+        "o"
+      ],
+      [
+        "Ġt",
+        "hat"
+      ],
+      [
+        "Ġ",
+        "h"
+      ],
+      [
+        "k",
+        "e"
+      ],
+      [
+        "Ġ",
+        "Y"
+      ],
+      [
+        "Ġ",
+        "on"
+      ],
+      [
+        "o",
+        "m"
+      ],
+      [
+        "a",
+        "y"
+      ],
+      [
+        "i",
+        "d"
+      ],
+      [
+        "Ġm",
+        "e"
+      ],
+      [
+        "u",
+        "t"
+      ],
+      [
+        "Ġ",
+        "ha"
+      ],
+      [
+        "e",
+        "ll"
+      ],
+      [
+        "Ġd",
+        "o"
+      ],
+      [
+        "g",
+        "h"
+      ],
+      [
+        "a",
+        "l"
+      ],
+      [
+        "Ġ",
+        "e"
+      ],
+      [
+        "Ġ",
+        "M"
+      ],
+      [
+        "ou",
+        "t"
+      ],
+      [
+        ".",
+        "."
+      ],
+      [
+        "Ġs",
+        "h"
+      ],
+      [
+        "l",
+        "d"
+      ],
+      [
+        "Ġ",
+        "A"
+      ],
+      [
+        "Ġ",
+        "B"
+      ],
+      [
+        "Ġ",
+        "is"
+      ],
+      [
+        "'",
+        "m"
+      ],
+      [
+        "Ġf",
+        "uck"
+      ],
+      [
+        "Ġ",
+        "k"
+      ],
+      [
+        "c",
+        "h"
+      ],
+      [
+        "Ġyou",
+        "r"
+      ],
+      [
+        "'",
+        "re"
+      ],
+      [
+        "ĠY",
+        "ou"
+      ],
+      [
+        "a",
+        "d"
+      ],
+      [
+        "Ġd",
+        "on"
+      ],
+      [
+        "Ġth",
+        "is"
+      ],
+      [
+        "c",
+        "e"
+      ],
+      [
+        "a",
+        "m"
+      ],
+      [
+        "v",
+        "er"
+      ],
+      [
+        "Ġ",
+        "H"
+      ],
+      [
+        "r",
+        "i"
+      ],
+      [
+        "gh",
+        "t"
+      ],
+      [
+        "Ġ",
+        "N"
+      ],
+      [
+        "n",
+        "a"
+      ],
+      [
+        "Ġ",
+        "S"
+      ],
+      [
+        "Ġw",
+        "e"
+      ],
+      [
+        "Ġw",
+        "as"
+      ],
+      [
+        "Ġm",
+        "y"
+      ],
+      [
+        "i",
+        "m"
+      ],
+      [
+        "Ġw",
+        "hat"
+      ],
+      [
+        "i",
+        "f"
+      ],
+      [
+        "Ġs",
+        "t"
+      ],
+      [
+        "â",
+        "Ģ"
+      ],
+      [
+        "Ġ",
+        "âĢ"
+      ],
+      [
+        "he",
+        "r"
+      ],
+      [
+        "ĠW",
+        "hat"
+      ],
+      [
+        "ĠâĢ",
+        "ĵ"
+      ],
+      [
+        "a",
+        "ll"
+      ],
+      [
+        "Ġa",
+        "s"
+      ],
+      [
+        "Ġa",
+        "n"
+      ],
+      [
+        "i",
+        "ll"
+      ],
+      [
+        "Ġ",
+        "u"
+      ],
+      [
+        "Ġfuck",
+        "in"
+      ],
+      [
+        "en",
+        "t"
+      ],
+      [
+        "Ġ",
+        "D"
+      ],
+      [
+        "Ġg",
+        "o"
+      ],
+      [
+        "Ġl",
+        "i"
+      ],
+      [
+        "ou",
+        "ld"
+      ],
+      [
+        "ĠT",
+        "he"
+      ],
+      [
+        "Ġ",
+        "j"
+      ],
+      [
+        "Ġk",
+        "n"
+      ],
+      [
+        "s",
+        "t"
+      ],
+      [
+        "Ġw",
+        "it"
+      ],
+      [
+        "Ġ",
+        "re"
+      ],
+      [
+        "Ġg",
+        "on"
+      ],
+      [
+        "Ġg",
+        "ot"
+      ],
+      [
+        "Ġf",
+        "or"
+      ],
+      [
+        "i",
+        "e"
+      ],
+      [
+        "us",
+        "t"
+      ],
+      [
+        "Ġgon",
+        "na"
+      ],
+      [
+        "r",
+        "o"
+      ],
+      [
+        "Ġ",
+        "J"
+      ],
+      [
+        "Ġkn",
+        "ow"
+      ],
+      [
+        "e",
+        "m"
+      ],
+      [
+        "Ġ",
+        "'"
+      ],
+      [
+        "Ġwit",
+        "h"
+      ],
+      [
+        "Ġg",
+        "et"
+      ],
+      [
+        "Ġli",
+        "ke"
+      ],
+      [
+        "ĠI",
+        "t"
+      ],
+      [
+        "Ġ",
+        "out"
+      ],
+      [
+        "Ġn",
+        "e"
+      ],
+      [
+        "s",
+        "e"
+      ],
+      [
+        "Ġm",
+        "an"
+      ],
+      [
+        "..",
+        "."
+      ],
+      [
+        "c",
+        "t"
+      ],
+      [
+        "i",
+        "ve"
+      ],
+      [
+        "an",
+        "t"
+      ],
+      [
+        "Ġu",
+        "p"
+      ],
+      [
+        "i",
+        "r"
+      ],
+      [
+        "Ġthe",
+        "y"
+      ],
+      [
+        "h",
+        "o"
+      ],
+      [
+        "Ġn",
+        "ot"
+      ],
+      [
+        "b",
+        "out"
+      ],
+      [
+        "Ġ",
+        "C"
+      ],
+      [
+        "Ġd",
+        "id"
+      ],
+      [
+        "oo",
+        "d"
+      ],
+      [
+        "Ġsh",
+        "it"
+      ],
+      [
+        "'",
+        "ll"
+      ],
+      [
+        "Ġ",
+        "G"
+      ],
+      [
+        "a",
+        "g"
+      ],
+      [
+        "Ġ",
+        "F"
+      ],
+      [
+        "oo",
+        "k"
+      ],
+      [
+        "a",
+        "ke"
+      ],
+      [
+        "i",
+        "on"
+      ],
+      [
+        "Ġ",
+        "O"
+      ],
+      [
+        "Ġn",
+        "o"
+      ],
+      [
+        "om",
+        "e"
+      ],
+      [
+        "ĠB",
+        "ut"
+      ],
+      [
+        "i",
+        "l"
+      ],
+      [
+        "o",
+        "p"
+      ],
+      [
+        "u",
+        "n"
+      ],
+      [
+        "i",
+        "g"
+      ],
+      [
+        "Ġj",
+        "ust"
+      ],
+      [
+        "a",
+        "k"
+      ],
+      [
+        "Ġon",
+        "e"
+      ],
+      [
+        "a",
+        "ck"
+      ],
+      [
+        "t",
+        "er"
+      ],
+      [
+        "Ġa",
+        "in"
+      ],
+      [
+        "in",
+        "k"
+      ],
+      [
+        "Ġs",
+        "e"
+      ],
+      [
+        "in",
+        "d"
+      ],
+      [
+        "Ġhe",
+        "r"
+      ],
+      [
+        "Ġhe",
+        "re"
+      ],
+      [
+        "o",
+        "re"
+      ],
+      [
+        "he",
+        "n"
+      ],
+      [
+        "Ġa",
+        "bout"
+      ],
+      [
+        "ar",
+        "s"
+      ],
+      [
+        "l",
+        "y"
+      ],
+      [
+        "o",
+        "d"
+      ],
+      [
+        "t",
+        "a"
+      ],
+      [
+        "es",
+        "s"
+      ],
+      [
+        "r",
+        "y"
+      ],
+      [
+        "Ġb",
+        "ut"
+      ],
+      [
+        "Ġc",
+        "an"
+      ],
+      [
+        "ot",
+        "her"
+      ],
+      [
+        "ĠW",
+        "e"
+      ],
+      [
+        "e",
+        "a"
+      ],
+      [
+        "p",
+        "p"
+      ],
+      [
+        "er",
+        "s"
+      ],
+      [
+        "al",
+        "k"
+      ],
+      [
+        "ĠA",
+        "nd"
+      ],
+      [
+        "Ġ",
+        "P"
+      ],
+      [
+        "Ġ",
+        "if"
+      ],
+      [
+        "i",
+        "ght"
+      ],
+      [
+        "u",
+        "r"
+      ],
+      [
+        "Ġ",
+        "L"
+      ],
+      [
+        "ĠT",
+        "hat"
+      ],
+      [
+        "Ġha",
+        "ve"
+      ],
+      [
+        "ĠW",
+        "ell"
+      ],
+      [
+        "am",
+        "e"
+      ],
+      [
+        "ri",
+        "ght"
+      ],
+      [
+        "ĠN",
+        "o"
+      ],
+      [
+        "r",
+        "a"
+      ],
+      [
+        "Ġa",
+        "ll"
+      ],
+      [
+        "Ġw",
+        "ant"
+      ],
+      [
+        "as",
+        "t"
+      ],
+      [
+        "r",
+        "ou"
+      ],
+      [
+        "u",
+        "l"
+      ],
+      [
+        "Ġ",
+        "R"
+      ],
+      [
+        "q",
+        "u"
+      ],
+      [
+        "Ġthe",
+        "re"
+      ],
+      [
+        "Ġd",
+        "e"
+      ],
+      [
+        "an",
+        "d"
+      ],
+      [
+        "b",
+        "le"
+      ],
+      [
+        "Ġ",
+        "V"
+      ],
+      [
+        "Ġn",
+        "ow"
+      ],
+      [
+        "Ġh",
+        "is"
+      ],
+      [
+        "Ġas",
+        "s"
+      ],
+      [
+        "t",
+        "h"
+      ],
+      [
+        "Ġ",
+        "right"
+      ],
+      [
+        "Ġa",
+        "t"
+      ],
+      [
+        "Ġw",
+        "hen"
+      ],
+      [
+        "it",
+        "t"
+      ],
+      [
+        "Ġo",
+        "r"
+      ],
+      [
+        "Ġth",
+        "ink"
+      ],
+      [
+        "ĠN",
+        "ow"
+      ],
+      [
+        "Ġa",
+        "re"
+      ],
+      [
+        "Ġw",
+        "at"
+      ],
+      [
+        "Ġs",
+        "o"
+      ],
+      [
+        "Ġs",
+        "he"
+      ],
+      [
+        "Ġs",
+        "ay"
+      ],
+      [
+        "o",
+        "s"
+      ],
+      [
+        "Ġ",
+        "\""
+      ],
+      [
+        "Ġg",
+        "ood"
+      ],
+      [
+        "Ġf",
+        "r"
+      ],
+      [
+        "a",
+        "ce"
+      ],
+      [
+        "i",
+        "c"
+      ],
+      [
+        "Ġme",
+        "an"
+      ],
+      [
+        "ell",
+        "us"
+      ],
+      [
+        "ĠH",
+        "e"
+      ],
+      [
+        "ars",
+        "ellus"
+      ],
+      [
+        "Ġw",
+        "ho"
+      ],
+      [
+        "ar",
+        "t"
+      ],
+      [
+        "us",
+        "e"
+      ],
+      [
+        "ĠM",
+        "arsellus"
+      ],
+      [
+        "Ġne",
+        "ver"
+      ],
+      [
+        "Ġw",
+        "or"
+      ],
+      [
+        "ĠI",
+        "f"
+      ],
+      [
+        "on",
+        "e"
+      ],
+      [
+        "Ġan",
+        "y"
+      ],
+      [
+        "i",
+        "ck"
+      ],
+      [
+        "v",
+        "en"
+      ],
+      [
+        "Ġt",
+        "alk"
+      ],
+      [
+        "ou",
+        "r"
+      ],
+      [
+        "Ġc",
+        "all"
+      ],
+      [
+        "Ġp",
+        "l"
+      ],
+      [
+        "ĠD",
+        "on"
+      ],
+      [
+        "ag",
+        "e"
+      ],
+      [
+        "o",
+        "y"
+      ],
+      [
+        "u",
+        "y"
+      ],
+      [
+        "Ġt",
+        "ell"
+      ],
+      [
+        "Ġs",
+        "u"
+      ],
+      [
+        "Ġe",
+        "ver"
+      ],
+      [
+        "Ġwat",
+        "ch"
+      ],
+      [
+        "e",
+        "e"
+      ],
+      [
+        "f",
+        "uck"
+      ],
+      [
+        "o",
+        "l"
+      ],
+      [
+        "t",
+        "y"
+      ],
+      [
+        "Ġw",
+        "ould"
+      ],
+      [
+        "ow",
+        "n"
+      ],
+      [
+        "as",
+        "s"
+      ],
+      [
+        "oo",
+        "l"
+      ],
+      [
+        "other",
+        "fuck"
+      ],
+      [
+        "a",
+        "b"
+      ],
+      [
+        "p",
+        "e"
+      ],
+      [
+        "Ġy",
+        "a"
+      ],
+      [
+        "Ġb",
+        "l"
+      ],
+      [
+        "Ġc",
+        "ar"
+      ],
+      [
+        "es",
+        "t"
+      ],
+      [
+        "Ġe",
+        "x"
+      ],
+      [
+        "ĠV",
+        "in"
+      ],
+      [
+        "w",
+        "o"
+      ],
+      [
+        "Ġg",
+        "ive"
+      ],
+      [
+        "ĠT",
+        "h"
+      ],
+      [
+        "Ġof",
+        "f"
+      ],
+      [
+        "ĠJ",
+        "im"
+      ],
+      [
+        "od",
+        "y"
+      ],
+      [
+        "Ġfr",
+        "om"
+      ],
+      [
+        "b",
+        "er"
+      ],
+      [
+        "d",
+        "am"
+      ],
+      [
+        "g",
+        "er"
+      ],
+      [
+        "Ġ",
+        "E"
+      ],
+      [
+        "Ġ",
+        "us"
+      ],
+      [
+        "Ġt",
+        "ake"
+      ],
+      [
+        "Ġs",
+        "ome"
+      ],
+      [
+        "Ġm",
+        "otherfuck"
+      ],
+      [
+        "Ġl",
+        "ook"
+      ],
+      [
+        "Ġh",
+        "ow"
+      ],
+      [
+        "Ġha",
+        "d"
+      ],
+      [
+        "Ġne",
+        "ed"
+      ],
+      [
+        "a",
+        "c"
+      ],
+      [
+        "c",
+        "ent"
+      ],
+      [
+        "n",
+        "t"
+      ],
+      [
+        "o",
+        "ot"
+      ],
+      [
+        "ou",
+        "s"
+      ],
+      [
+        "Ġs",
+        "a"
+      ],
+      [
+        "an",
+        "na"
+      ],
+      [
+        "Ġl",
+        "itt"
+      ],
+      [
+        "at",
+        "e"
+      ],
+      [
+        "im",
+        "e"
+      ],
+      [
+        "Ġlitt",
+        "le"
+      ],
+      [
+        "'",
+        "ve"
+      ],
+      [
+        "c",
+        "a"
+      ],
+      [
+        "k",
+        "ay"
+      ],
+      [
+        "Ġ",
+        "qu"
+      ],
+      [
+        "in",
+        "e"
+      ],
+      [
+        "on",
+        "g"
+      ],
+      [
+        "Ġb",
+        "ack"
+      ],
+      [
+        "Ġc",
+        "ould"
+      ],
+      [
+        "Ġc",
+        "ool"
+      ],
+      [
+        "Ġth",
+        "ing"
+      ],
+      [
+        "if",
+        "e"
+      ],
+      [
+        "ĠJim",
+        "m"
+      ],
+      [
+        "h",
+        "y"
+      ],
+      [
+        "Ġt",
+        "ime"
+      ],
+      [
+        "ha",
+        "n"
+      ],
+      [
+        "Ġb",
+        "et"
+      ],
+      [
+        "Ġl",
+        "et"
+      ],
+      [
+        "Ġp",
+        "ro"
+      ],
+      [
+        "Ġhe",
+        "ar"
+      ],
+      [
+        "Ġin",
+        "t"
+      ],
+      [
+        "om",
+        "et"
+      ],
+      [
+        "Ġdo",
+        "es"
+      ],
+      [
+        "Ġsh",
+        "ould"
+      ],
+      [
+        "ĠS",
+        "o"
+      ],
+      [
+        "ĠJimm",
+        "ie"
+      ],
+      [
+        "b",
+        "ody"
+      ],
+      [
+        "e",
+        "p"
+      ],
+      [
+        "e",
+        "nd"
+      ],
+      [
+        "Ġt",
+        "wo"
+      ],
+      [
+        "Ġw",
+        "ay"
+      ],
+      [
+        "Ġw",
+        "anna"
+      ],
+      [
+        "Ġs",
+        "omet"
+      ],
+      [
+        "Ġd",
+        "own"
+      ],
+      [
+        "Ġha",
+        "nd"
+      ],
+      [
+        "Ġdid",
+        "n"
+      ],
+      [
+        "ea",
+        "h"
+      ],
+      [
+        "h",
+        "i"
+      ],
+      [
+        "n",
+        "y"
+      ],
+      [
+        "he",
+        "re"
+      ],
+      [
+        "Ġth",
+        "rou"
+      ],
+      [
+        "ĠH",
+        "ow"
+      ],
+      [
+        "ĠThe",
+        "y"
+      ],
+      [
+        "Ġsomet",
+        "h"
+      ],
+      [
+        "Ġthrou",
+        "gh"
+      ],
+      [
+        "'",
+        "d"
+      ],
+      [
+        "Ġ",
+        "U"
+      ],
+      [
+        "Ġ",
+        "r"
+      ],
+      [
+        "re",
+        "t"
+      ],
+      [
+        "Ġg",
+        "uy"
+      ],
+      [
+        "Ġo",
+        "ver"
+      ],
+      [
+        "Ġh",
+        "im"
+      ],
+      [
+        "ĠY",
+        "eah"
+      ],
+      [
+        "id",
+        "e"
+      ],
+      [
+        "Ġde",
+        "ad"
+      ],
+      [
+        "ca",
+        "use"
+      ],
+      [
+        "g",
+        "e"
+      ],
+      [
+        "i",
+        "es"
+      ],
+      [
+        "u",
+        "e"
+      ],
+      [
+        "u",
+        "m"
+      ],
+      [
+        "Ġ",
+        "ro"
+      ],
+      [
+        "Ġw",
+        "ill"
+      ],
+      [
+        "re",
+        "d"
+      ],
+      [
+        "on",
+        "t"
+      ],
+      [
+        "Ġc",
+        "om"
+      ],
+      [
+        "Ġl",
+        "e"
+      ],
+      [
+        "at",
+        "ion"
+      ],
+      [
+        "Ġha",
+        "pp"
+      ],
+      [
+        "all",
+        "y"
+      ],
+      [
+        "Ġgot",
+        "ta"
+      ],
+      [
+        "ĠJ",
+        "ul"
+      ],
+      [
+        "ĠVin",
+        "cent"
+      ],
+      [
+        "ĠTh",
+        "is"
+      ],
+      [
+        "a",
+        "u"
+      ],
+      [
+        "a",
+        "in"
+      ],
+      [
+        "d",
+        "y"
+      ],
+      [
+        "g",
+        "et"
+      ],
+      [
+        "l",
+        "f"
+      ],
+      [
+        "n",
+        "e"
+      ],
+      [
+        "v",
+        "in"
+      ],
+      [
+        "Ġ",
+        "..."
+      ],
+      [
+        "Ġb",
+        "r"
+      ],
+      [
+        "Ġb",
+        "y"
+      ],
+      [
+        "Ġm",
+        "ass"
+      ],
+      [
+        "Ġd",
+        "ay"
+      ],
+      [
+        "Ġf",
+        "ind"
+      ],
+      [
+        "Ġc",
+        "o"
+      ],
+      [
+        "Ġl",
+        "o"
+      ],
+      [
+        "Ġn",
+        "ame"
+      ],
+      [
+        "as",
+        "e"
+      ],
+      [
+        "Ġsh",
+        "ot"
+      ],
+      [
+        "Ġk",
+        "ill"
+      ],
+      [
+        "Ġre",
+        "m"
+      ],
+      [
+        "a",
+        "ct"
+      ],
+      [
+        "Ġ",
+        "our"
+      ],
+      [
+        "Ġs",
+        "ame"
+      ],
+      [
+        "re",
+        "ak"
+      ],
+      [
+        "Ġb",
+        "it"
+      ],
+      [
+        "Ġm",
+        "ake"
+      ],
+      [
+        "Ġm",
+        "ore"
+      ],
+      [
+        "Ġg",
+        "re"
+      ],
+      [
+        "is",
+        "h"
+      ],
+      [
+        "Ġwe",
+        "re"
+      ],
+      [
+        "ĠBut",
+        "ch"
+      ],
+      [
+        "ĠJul",
+        "es"
+      ],
+      [
+        ".",
+        "\""
+      ],
+      [
+        "c",
+        "i"
+      ],
+      [
+        "i",
+        "ce"
+      ],
+      [
+        "Ġ",
+        "K"
+      ],
+      [
+        "re",
+        "n"
+      ],
+      [
+        "Ġf",
+        "ight"
+      ],
+      [
+        "Ġf",
+        "oot"
+      ],
+      [
+        "Ġc",
+        "ou"
+      ],
+      [
+        "Ġbe",
+        "en"
+      ],
+      [
+        "Ġsh",
+        "ow"
+      ],
+      [
+        "ĠD",
+        "o"
+      ],
+      [
+        "ĠThe",
+        "n"
+      ],
+      [
+        "Ġj",
+        "o"
+      ],
+      [
+        "em",
+        "ber"
+      ],
+      [
+        "ir",
+        "st"
+      ],
+      [
+        "ĠG",
+        "od"
+      ],
+      [
+        "Ġint",
+        "o"
+      ],
+      [
+        "a",
+        "p"
+      ],
+      [
+        "a",
+        "re"
+      ],
+      [
+        "f",
+        "f"
+      ],
+      [
+        "o",
+        "se"
+      ],
+      [
+        "t",
+        "her"
+      ],
+      [
+        "w",
+        "ay"
+      ],
+      [
+        "re",
+        "e"
+      ],
+      [
+        "Ġb",
+        "ig"
+      ],
+      [
+        "Ġd",
+        "r"
+      ],
+      [
+        "is",
+        "t"
+      ],
+      [
+        "or",
+        "ry"
+      ],
+      [
+        "Ġp",
+        "r"
+      ],
+      [
+        "Ġth",
+        "ose"
+      ],
+      [
+        "ĠY",
+        "es"
+      ],
+      [
+        "Ġdo",
+        "in"
+      ],
+      [
+        "ri",
+        "end"
+      ],
+      [
+        "Ġas",
+        "k"
+      ],
+      [
+        "Ġtalk",
+        "in"
+      ],
+      [
+        "dam",
+        "n"
+      ],
+      [
+        "Ġmotherfuck",
+        "er"
+      ],
+      [
+        "b",
+        "e"
+      ],
+      [
+        "e",
+        "op"
+      ],
+      [
+        "o",
+        "ck"
+      ],
+      [
+        "u",
+        "re"
+      ],
+      [
+        "ou",
+        "se"
+      ],
+      [
+        "Ġa",
+        "g"
+      ],
+      [
+        "Ġa",
+        "l"
+      ],
+      [
+        "Ġs",
+        "p"
+      ],
+      [
+        "Ġg",
+        "un"
+      ],
+      [
+        "Ġf",
+        "irst"
+      ],
+      [
+        "an",
+        "ce"
+      ],
+      [
+        "nd",
+        "er"
+      ],
+      [
+        "Ġto",
+        "o"
+      ],
+      [
+        "ar",
+        "k"
+      ],
+      [
+        "Ġse",
+        "e"
+      ],
+      [
+        "ble",
+        "m"
+      ],
+      [
+        "one",
+        "y"
+      ],
+      [
+        "Ġsa",
+        "id"
+      ],
+      [
+        "Ġpro",
+        "blem"
+      ],
+      [
+        "Ġhapp",
+        "en"
+      ],
+      [
+        "Ġmass",
+        "age"
+      ],
+      [
+        "eop",
+        "le"
+      ],
+      [
+        "i",
+        "a"
+      ],
+      [
+        "o",
+        "x"
+      ],
+      [
+        "r",
+        "and"
+      ],
+      [
+        "u",
+        "ll"
+      ],
+      [
+        "w",
+        "e"
+      ],
+      [
+        "Ġ",
+        "ke"
+      ],
+      [
+        "Ġt",
+        "han"
+      ],
+      [
+        "Ġg",
+        "i"
+      ],
+      [
+        "an",
+        "k"
+      ],
+      [
+        "Ġo",
+        "ther"
+      ],
+      [
+        "es",
+        "e"
+      ],
+      [
+        "Ġl",
+        "ot"
+      ],
+      [
+        "ĠW",
+        "ho"
+      ],
+      [
+        "Ġp",
+        "eople"
+      ],
+      [
+        "Ġh",
+        "ome"
+      ],
+      [
+        "ĠS",
+        "he"
+      ],
+      [
+        "ĠO",
+        "h"
+      ],
+      [
+        "ĠO",
+        "kay"
+      ],
+      [
+        "ĠL",
+        "ook"
+      ],
+      [
+        "th",
+        "ing"
+      ],
+      [
+        "Ġpl",
+        "ace"
+      ],
+      [
+        "Ġbet",
+        "ter"
+      ],
+      [
+        "Ġrem",
+        "ember"
+      ],
+      [
+        "c",
+        "c"
+      ],
+      [
+        "e",
+        "w"
+      ],
+      [
+        "e",
+        "ct"
+      ],
+      [
+        "f",
+        "or"
+      ],
+      [
+        "h",
+        "one"
+      ],
+      [
+        "n",
+        "g"
+      ],
+      [
+        "Ġ",
+        "v"
+      ],
+      [
+        "Ġt",
+        "r"
+      ],
+      [
+        "ou",
+        "ght"
+      ],
+      [
+        "Ġw",
+        "alk"
+      ],
+      [
+        "Ġw",
+        "ife"
+      ],
+      [
+        "Ġs",
+        "ha"
+      ],
+      [
+        "re",
+        "s"
+      ],
+      [
+        "it",
+        "e"
+      ],
+      [
+        "Ġb",
+        "reak"
+      ],
+      [
+        "Ġm",
+        "o"
+      ],
+      [
+        "Ġf",
+        "riend"
+      ],
+      [
+        "ĠW",
+        "all"
+      ],
+      [
+        "Ġn",
+        "ig"
+      ],
+      [
+        "or",
+        "n"
+      ],
+      [
+        "Ġh",
+        "ouse"
+      ],
+      [
+        "Ġgo",
+        "d"
+      ],
+      [
+        "st",
+        "er"
+      ],
+      [
+        "rou",
+        "nd"
+      ],
+      [
+        "Ġgre",
+        "at"
+      ],
+      [
+        "ĠWall",
+        "ace"
+      ],
+      [
+        "'",
+        "."
+      ],
+      [
+        "a",
+        "it"
+      ],
+      [
+        "a",
+        "ve"
+      ],
+      [
+        "f",
+        "ore"
+      ],
+      [
+        "l",
+        "p"
+      ],
+      [
+        "p",
+        "le"
+      ],
+      [
+        "u",
+        "d"
+      ],
+      [
+        "w",
+        "n"
+      ],
+      [
+        "Ġw",
+        "hy"
+      ],
+      [
+        "Ġw",
+        "here"
+      ],
+      [
+        "Ġs",
+        "it"
+      ],
+      [
+        "Ġs",
+        "pe"
+      ],
+      [
+        "Ġs",
+        "orry"
+      ],
+      [
+        "it",
+        "y"
+      ],
+      [
+        "Ġb",
+        "oy"
+      ],
+      [
+        "Ġthe",
+        "n"
+      ],
+      [
+        "Ġf",
+        "at"
+      ],
+      [
+        "Ġf",
+        "ive"
+      ],
+      [
+        "Ġc",
+        "h"
+      ],
+      [
+        "Ġc",
+        "ha"
+      ],
+      [
+        "Ġc",
+        "le"
+      ],
+      [
+        "Ġhe",
+        "lp"
+      ],
+      [
+        "Ġe",
+        "at"
+      ],
+      [
+        "Ġe",
+        "ven"
+      ],
+      [
+        "ĠM",
+        "ar"
+      ],
+      [
+        "ĠM",
+        "ia"
+      ],
+      [
+        "ĠA",
+        "m"
+      ],
+      [
+        "ĠN",
+        "ot"
+      ],
+      [
+        "Ġst",
+        "ill"
+      ],
+      [
+        "ĠD",
+        "id"
+      ],
+      [
+        "Ġre",
+        "al"
+      ],
+      [
+        "Ġfor",
+        "get"
+      ],
+      [
+        "Ġnot",
+        "h"
+      ],
+      [
+        "ĠO",
+        "ne"
+      ],
+      [
+        "ak",
+        "es"
+      ],
+      [
+        "Ġsu",
+        "re"
+      ],
+      [
+        "ab",
+        "y"
+      ],
+      [
+        "hi",
+        "ch"
+      ],
+      [
+        "Ġsometh",
+        "ing"
+      ],
+      [
+        "Ġguy",
+        "s"
+      ],
+      [
+        "Ġlo",
+        "ve"
+      ],
+      [
+        "Ġdr",
+        "ink"
+      ],
+      [
+        "Ġag",
+        "ain"
+      ],
+      [
+        "Ġgod",
+        "damn"
+      ],
+      [
+        "f",
+        "ast"
+      ],
+      [
+        "p",
+        "t"
+      ],
+      [
+        "u",
+        "ch"
+      ],
+      [
+        "Ġ",
+        "Q"
+      ],
+      [
+        "in",
+        "ess"
+      ],
+      [
+        "Ġw",
+        "on"
+      ],
+      [
+        "Ġw",
+        "ait"
+      ],
+      [
+        "Ġs",
+        "m"
+      ],
+      [
+        "Ġb",
+        "us"
+      ],
+      [
+        "Ġb",
+        "ook"
+      ],
+      [
+        "Ġb",
+        "aby"
+      ],
+      [
+        "Ġm",
+        "orn"
+      ],
+      [
+        "Ġf",
+        "ast"
+      ],
+      [
+        "Ġc",
+        "ont"
+      ],
+      [
+        "Ġo",
+        "kay"
+      ],
+      [
+        "Ġp",
+        "ie"
+      ],
+      [
+        "le",
+        "m"
+      ],
+      [
+        "Ġbe",
+        "fore"
+      ],
+      [
+        "Ġha",
+        "s"
+      ],
+      [
+        "ĠA",
+        "re"
+      ],
+      [
+        "ad",
+        "y"
+      ],
+      [
+        "ad",
+        "dy"
+      ],
+      [
+        "ver",
+        "y"
+      ],
+      [
+        "Ġst",
+        "op"
+      ],
+      [
+        "ĠC",
+        "he"
+      ],
+      [
+        "ĠF",
+        "or"
+      ],
+      [
+        "un",
+        "ch"
+      ],
+      [
+        "Ġwor",
+        "k"
+      ],
+      [
+        "Ġever",
+        "y"
+      ],
+      [
+        "Ġhear",
+        "d"
+      ],
+      [
+        "ret",
+        "ty"
+      ],
+      [
+        "Ġbreak",
+        "fast"
+      ],
+      [
+        "Ġcle",
+        "an"
+      ],
+      [
+        "Ġbus",
+        "iness"
+      ],
+      [
+        "g",
+        "ar"
+      ],
+      [
+        "g",
+        "ers"
+      ],
+      [
+        "o",
+        "ll"
+      ],
+      [
+        "u",
+        "ation"
+      ],
+      [
+        "y",
+        "e"
+      ],
+      [
+        "ou",
+        "nd"
+      ],
+      [
+        "Ġw",
+        "r"
+      ],
+      [
+        "Ġb",
+        "ad"
+      ],
+      [
+        "Ġb",
+        "uy"
+      ],
+      [
+        "Ġb",
+        "ank"
+      ],
+      [
+        "Ġm",
+        "in"
+      ],
+      [
+        "Ġm",
+        "et"
+      ],
+      [
+        "Ġm",
+        "uch"
+      ],
+      [
+        "Ġd",
+        "if"
+      ],
+      [
+        "Ġd",
+        "ie"
+      ],
+      [
+        "Ġf",
+        "if"
+      ],
+      [
+        "is",
+        "s"
+      ],
+      [
+        "Ġc",
+        "ome"
+      ],
+      [
+        "Ġto",
+        "m"
+      ],
+      [
+        "Ġto",
+        "ld"
+      ],
+      [
+        "Ġl",
+        "ea"
+      ],
+      [
+        "Ġp",
+        "ot"
+      ],
+      [
+        "et",
+        "s"
+      ],
+      [
+        "Ġth",
+        "ree"
+      ],
+      [
+        "at",
+        "h"
+      ],
+      [
+        "oo",
+        "m"
+      ],
+      [
+        "ut",
+        "e"
+      ],
+      [
+        "ĠM",
+        "e"
+      ],
+      [
+        "ĠM",
+        "r"
+      ],
+      [
+        "ĠM",
+        "y"
+      ],
+      [
+        "ĠS",
+        "t"
+      ],
+      [
+        "Ġu",
+        "n"
+      ],
+      [
+        "Ġu",
+        "nder"
+      ],
+      [
+        "Ġgo",
+        "in"
+      ],
+      [
+        "se",
+        "lf"
+      ],
+      [
+        "os",
+        "ed"
+      ],
+      [
+        "Ġcall",
+        "ed"
+      ],
+      [
+        "ee",
+        "l"
+      ],
+      [
+        "Ġsometh",
+        "in"
+      ],
+      [
+        "Ġro",
+        "b"
+      ],
+      [
+        "Ġbit",
+        "ch"
+      ],
+      [
+        "ff",
+        "ee"
+      ],
+      [
+        "Ġke",
+        "ep"
+      ],
+      [
+        "Ġsit",
+        "uation"
+      ],
+      [
+        "Ġdif",
+        "f"
+      ],
+      [
+        "?",
+        "!"
+      ],
+      [
+        "Z",
+        "ed"
+      ],
+      [
+        "c",
+        "es"
+      ],
+      [
+        "c",
+        "le"
+      ],
+      [
+        "g",
+        "al"
+      ],
+      [
+        "h",
+        "u"
+      ],
+      [
+        "i",
+        "er"
+      ],
+      [
+        "l",
+        "es"
+      ],
+      [
+        "l",
+        "ess"
+      ],
+      [
+        "n",
+        "ess"
+      ],
+      [
+        "o",
+        "ld"
+      ],
+      [
+        "p",
+        "en"
+      ],
+      [
+        "u",
+        "p"
+      ],
+      [
+        "Ġ",
+        "Zed"
+      ],
+      [
+        "Ġt",
+        "ast"
+      ],
+      [
+        "he",
+        "d"
+      ],
+      [
+        "Ġa",
+        "pp"
+      ],
+      [
+        "Ġa",
+        "cc"
+      ],
+      [
+        "Ġw",
+        "ent"
+      ],
+      [
+        "it",
+        "her"
+      ],
+      [
+        "Ġm",
+        "ay"
+      ],
+      [
+        "Ġm",
+        "ad"
+      ],
+      [
+        "Ġm",
+        "ir"
+      ],
+      [
+        "Ġthe",
+        "m"
+      ],
+      [
+        "Ġd",
+        "i"
+      ],
+      [
+        "Ġg",
+        "rand"
+      ],
+      [
+        "Ġf",
+        "e"
+      ],
+      [
+        "Ġf",
+        "eel"
+      ],
+      [
+        "is",
+        "e"
+      ],
+      [
+        "Ġl",
+        "ife"
+      ],
+      [
+        "Ġl",
+        "au"
+      ],
+      [
+        "ĠW",
+        "hen"
+      ],
+      [
+        "ĠW",
+        "hy"
+      ],
+      [
+        "Ġp",
+        "le"
+      ],
+      [
+        "Ġp",
+        "ut"
+      ],
+      [
+        "Ġp",
+        "op"
+      ],
+      [
+        "Ġp",
+        "hone"
+      ],
+      [
+        "Ġhe",
+        "ll"
+      ],
+      [
+        "Ġhe",
+        "art"
+      ],
+      [
+        "ĠT",
+        "ell"
+      ],
+      [
+        "Ġbe",
+        "l"
+      ],
+      [
+        "Ġbe",
+        "ll"
+      ],
+      [
+        "id",
+        "es"
+      ],
+      [
+        "Ġe",
+        "ither"
+      ],
+      [
+        "Ġst",
+        "or"
+      ],
+      [
+        "Ġst",
+        "art"
+      ],
+      [
+        "ent",
+        "lem"
+      ],
+      [
+        "Ġre",
+        "ally"
+      ],
+      [
+        "ĠJ",
+        "ust"
+      ],
+      [
+        "ĠG",
+        "ood"
+      ],
+      [
+        "os",
+        "s"
+      ],
+      [
+        "Ġany",
+        "thing"
+      ],
+      [
+        "pe",
+        "ct"
+      ],
+      [
+        "ĠVin",
+        "ce"
+      ],
+      [
+        "Ġnig",
+        "ger"
+      ],
+      [
+        "Ġmorn",
+        "ing"
+      ],
+      [
+        "entlem",
+        "en"
+      ],
+      [
+        "'",
+        "?"
+      ],
+      [
+        "a",
+        "v"
+      ],
+      [
+        "a",
+        "w"
+      ],
+      [
+        "e",
+        "re"
+      ],
+      [
+        "i",
+        "z"
+      ],
+      [
+        "l",
+        "i"
+      ],
+      [
+        "l",
+        "o"
+      ],
+      [
+        "n",
+        "ie"
+      ],
+      [
+        "p",
+        "l"
+      ],
+      [
+        "p",
+        "er"
+      ],
+      [
+        "r",
+        "or"
+      ],
+      [
+        "r",
+        "oom"
+      ],
+      [
+        "v",
+        "ent"
+      ],
+      [
+        "v",
+        "il"
+      ],
+      [
+        "w",
+        "an"
+      ],
+      [
+        "Ġ",
+        "id"
+      ],
+      [
+        "Ġa",
+        "d"
+      ],
+      [
+        "Ġa",
+        "round"
+      ],
+      [
+        "Ġw",
+        "ind"
+      ],
+      [
+        "Ġw",
+        "hich"
+      ],
+      [
+        "ĠI",
+        "n"
+      ],
+      [
+        "ĠI",
+        "s"
+      ],
+      [
+        "re",
+        "ct"
+      ],
+      [
+        "on",
+        "s"
+      ],
+      [
+        "Ġy",
+        "e"
+      ],
+      [
+        "Ġb",
+        "ur"
+      ],
+      [
+        "Ġb",
+        "unch"
+      ],
+      [
+        "Ġm",
+        "ind"
+      ],
+      [
+        "Ġthe",
+        "ir"
+      ],
+      [
+        "Ġg",
+        "u"
+      ],
+      [
+        "Ġg",
+        "it"
+      ],
+      [
+        "Ġg",
+        "ar"
+      ],
+      [
+        "Ġg",
+        "entlemen"
+      ],
+      [
+        "Ġf",
+        "ell"
+      ],
+      [
+        "Ġf",
+        "act"
+      ],
+      [
+        "Ġc",
+        "l"
+      ],
+      [
+        "ĠW",
+        "ol"
+      ],
+      [
+        "ĠW",
+        "here"
+      ],
+      [
+        "or",
+        "a"
+      ],
+      [
+        "Ġp",
+        "o"
+      ],
+      [
+        "Ġth",
+        "ought"
+      ],
+      [
+        "le",
+        "ep"
+      ],
+      [
+        "at",
+        "o"
+      ],
+      [
+        "ĠB",
+        "on"
+      ],
+      [
+        "ĠB",
+        "ig"
+      ],
+      [
+        "Ġfuck",
+        "ed"
+      ],
+      [
+        "Ġk",
+        "ind"
+      ],
+      [
+        "ĠYou",
+        "r"
+      ],
+      [
+        "ĠS",
+        "ure"
+      ],
+      [
+        "Ġst",
+        "ore"
+      ],
+      [
+        "Ġre",
+        "t"
+      ],
+      [
+        "ĠC",
+        "an"
+      ],
+      [
+        "un",
+        "ny"
+      ],
+      [
+        "Ġse",
+        "em"
+      ],
+      [
+        "ĠL",
+        "et"
+      ],
+      [
+        "ra",
+        "ct"
+      ],
+      [
+        "Ġfr",
+        "ont"
+      ],
+      [
+        "ic",
+        "al"
+      ],
+      [
+        "ĠHe",
+        "y"
+      ],
+      [
+        "Ġbl",
+        "ack"
+      ],
+      [
+        "Ġqu",
+        "ack"
+      ],
+      [
+        "Ġhand",
+        "s"
+      ],
+      [
+        "hi",
+        "le"
+      ],
+      [
+        "ĠU",
+        "n"
+      ],
+      [
+        "ret",
+        "t"
+      ],
+      [
+        "Ġle",
+        "gal"
+      ],
+      [
+        "Ġbr",
+        "ing"
+      ],
+      [
+        "Ġco",
+        "ffee"
+      ],
+      [
+        "Ġcou",
+        "ple"
+      ],
+      [
+        "Ġhappen",
+        "ed"
+      ],
+      [
+        "Ġsha",
+        "ke"
+      ],
+      [
+        "ĠQ",
+        "u"
+      ],
+      [
+        "ĠChe",
+        "ese"
+      ],
+      [
+        "Ġtom",
+        "ato"
+      ],
+      [
+        "Ġbel",
+        "ie"
+      ],
+      [
+        "Ġwind",
+        "ow"
+      ],
+      [
+        "ĠWol",
+        "f"
+      ],
+      [
+        "'",
+        ","
+      ],
+      [
+        "a",
+        "ch"
+      ],
+      [
+        "e",
+        "y"
+      ],
+      [
+        "f",
+        "ter"
+      ],
+      [
+        "i",
+        "en"
+      ],
+      [
+        "i",
+        "ble"
+      ],
+      [
+        "n",
+        "er"
+      ],
+      [
+        "o",
+        "ke"
+      ],
+      [
+        "p",
+        "ed"
+      ],
+      [
+        "p",
+        "her"
+      ],
+      [
+        "r",
+        "d"
+      ],
+      [
+        "r",
+        "ow"
+      ],
+      [
+        "t",
+        "e"
+      ],
+      [
+        "v",
+        "es"
+      ],
+      [
+        "v",
+        "ing"
+      ],
+      [
+        "z",
+        "e"
+      ],
+      [
+        "Ġ",
+        "im"
+      ],
+      [
+        "Ġt",
+        "e"
+      ],
+      [
+        "Ġt",
+        "ry"
+      ],
+      [
+        "ou",
+        "nt"
+      ],
+      [
+        "Ġa",
+        "b"
+      ],
+      [
+        "Ġa",
+        "m"
+      ],
+      [
+        "Ġa",
+        "ct"
+      ],
+      [
+        "Ġw",
+        "all"
+      ],
+      [
+        "Ġs",
+        "leep"
+      ],
+      [
+        "re",
+        "am"
+      ],
+      [
+        "on",
+        "d"
+      ],
+      [
+        "on",
+        "al"
+      ],
+      [
+        "Ġb",
+        "ed"
+      ],
+      [
+        "Ġb",
+        "all"
+      ],
+      [
+        "Ġb",
+        "ull"
+      ],
+      [
+        "Ġm",
+        "om"
+      ],
+      [
+        "Ġm",
+        "oney"
+      ],
+      [
+        "Ġd",
+        "ri"
+      ],
+      [
+        "Ġg",
+        "ir"
+      ],
+      [
+        "Ġg",
+        "ave"
+      ],
+      [
+        "Ġf",
+        "il"
+      ],
+      [
+        "Ġf",
+        "ace"
+      ],
+      [
+        "an",
+        "s"
+      ],
+      [
+        "is",
+        "ter"
+      ],
+      [
+        "Ġo",
+        "wn"
+      ],
+      [
+        "Ġl",
+        "uck"
+      ],
+      [
+        "Ġl",
+        "ast"
+      ],
+      [
+        "Ġl",
+        "ong"
+      ],
+      [
+        "ĠW",
+        "in"
+      ],
+      [
+        "or",
+        "m"
+      ],
+      [
+        "or",
+        "t"
+      ],
+      [
+        "Ġp",
+        "ers"
+      ],
+      [
+        "Ġp",
+        "ick"
+      ],
+      [
+        "Ġp",
+        "retty"
+      ],
+      [
+        "Ġp",
+        "ier"
+      ],
+      [
+        "ar",
+        "d"
+      ],
+      [
+        "Ġbe",
+        "cause"
+      ],
+      [
+        "Ġh",
+        "u"
+      ],
+      [
+        "Ġh",
+        "it"
+      ],
+      [
+        "Ġon",
+        "ly"
+      ],
+      [
+        "Ġdo",
+        "ll"
+      ],
+      [
+        "Ġe",
+        "vil"
+      ],
+      [
+        "ĠM",
+        "ac"
+      ],
+      [
+        "ĠA",
+        "n"
+      ],
+      [
+        "ĠA",
+        "ll"
+      ],
+      [
+        "ĠA",
+        "nt"
+      ],
+      [
+        "ĠB",
+        "rett"
+      ],
+      [
+        "Ġdon",
+        "e"
+      ],
+      [
+        "am",
+        "p"
+      ],
+      [
+        "Ġst",
+        "ick"
+      ],
+      [
+        "Ġgo",
+        "es"
+      ],
+      [
+        "Ġgo",
+        "ing"
+      ],
+      [
+        "ĠThe",
+        "re"
+      ],
+      [
+        "st",
+        "and"
+      ],
+      [
+        "Ġout",
+        "ta"
+      ],
+      [
+        "ant",
+        "s"
+      ],
+      [
+        "Ġup",
+        "on"
+      ],
+      [
+        "ĠF",
+        "uck"
+      ],
+      [
+        "ĠF",
+        "ab"
+      ],
+      [
+        "ig",
+        "n"
+      ],
+      [
+        "pp",
+        "osed"
+      ],
+      [
+        "ur",
+        "t"
+      ],
+      [
+        "ĠR",
+        "ock"
+      ],
+      [
+        "and",
+        "a"
+      ],
+      [
+        "th",
+        "y"
+      ],
+      [
+        "itt",
+        "in"
+      ],
+      [
+        "Ġsay",
+        "in"
+      ],
+      [
+        "Ġmean",
+        "s"
+      ],
+      [
+        "Ġwor",
+        "ld"
+      ],
+      [
+        "Ġsu",
+        "pposed"
+      ],
+      [
+        "Ġwould",
+        "n"
+      ],
+      [
+        "Ġlook",
+        "s"
+      ],
+      [
+        "ac",
+        "le"
+      ],
+      [
+        "Ġbet",
+        "we"
+      ],
+      [
+        "Ġdoes",
+        "n"
+      ],
+      [
+        "Ġhand",
+        "le"
+      ],
+      [
+        "ĠU",
+        "h"
+      ],
+      [
+        "Ġro",
+        "ad"
+      ],
+      [
+        "Ġcom",
+        "es"
+      ],
+      [
+        "au",
+        "ght"
+      ],
+      [
+        "Ġday",
+        "s"
+      ],
+      [
+        "Ġjo",
+        "b"
+      ],
+      [
+        "ster",
+        "dam"
+      ],
+      [
+        "ĠAm",
+        "sterdam"
+      ],
+      [
+        "Ġnoth",
+        "in"
+      ],
+      [
+        "Ġwr",
+        "ong"
+      ],
+      [
+        "Ġlea",
+        "ve"
+      ],
+      [
+        "Ġunder",
+        "stand"
+      ],
+      [
+        "Ġmir",
+        "acle"
+      ],
+      [
+        "Ġlau",
+        "gh"
+      ],
+      [
+        "Ġbell",
+        "y"
+      ],
+      [
+        "Ġid",
+        "ea"
+      ],
+      [
+        "Ġye",
+        "ars"
+      ],
+      [
+        "Ġgu",
+        "ess"
+      ],
+      [
+        "ĠBon",
+        "nie"
+      ],
+      [
+        "Ġkind",
+        "a"
+      ],
+      [
+        "Ġbelie",
+        "ve"
+      ],
+      [
+        "pher",
+        "d"
+      ],
+      [
+        "Ġfil",
+        "thy"
+      ],
+      [
+        "ĠAnt",
+        "wan"
+      ],
+      [
+        "Ġbetwe",
+        "en"
+      ],
+      [
+        ",",
+        "\""
+      ],
+      [
+        "W",
+        "hat"
+      ],
+      [
+        "a",
+        "le"
+      ],
+      [
+        "a",
+        "ble"
+      ],
+      [
+        "c",
+        "akes"
+      ],
+      [
+        "e",
+        "g"
+      ],
+      [
+        "e",
+        "l"
+      ],
+      [
+        "e",
+        "ous"
+      ],
+      [
+        "f",
+        "ul"
+      ],
+      [
+        "g",
+        "s"
+      ],
+      [
+        "i",
+        "o"
+      ],
+      [
+        "i",
+        "p"
+      ],
+      [
+        "i",
+        "x"
+      ],
+      [
+        "i",
+        "ous"
+      ],
+      [
+        "k",
+        "s"
+      ],
+      [
+        "p",
+        "a"
+      ],
+      [
+        "s",
+        "s"
+      ],
+      [
+        "s",
+        "ide"
+      ],
+      [
+        "w",
+        "er"
+      ],
+      [
+        "x",
+        "ic"
+      ],
+      [
+        "Ġ",
+        "2"
+      ],
+      [
+        "Ġ",
+        "en"
+      ],
+      [
+        "Ġ",
+        "use"
+      ],
+      [
+        "Ġ",
+        "ven"
+      ],
+      [
+        "Ġ",
+        "very"
+      ],
+      [
+        "Ġt",
+        "y"
+      ],
+      [
+        "Ġt",
+        "ou"
+      ],
+      [
+        "Ġt",
+        "ak"
+      ],
+      [
+        "he",
+        "s"
+      ],
+      [
+        "ou",
+        "gh"
+      ],
+      [
+        "Ġa",
+        "way"
+      ],
+      [
+        "in",
+        "t"
+      ],
+      [
+        "Ġs",
+        "ound"
+      ],
+      [
+        "on",
+        "y"
+      ],
+      [
+        "Ġy",
+        "et"
+      ],
+      [
+        "Ġb",
+        "ag"
+      ],
+      [
+        "Ġm",
+        "en"
+      ],
+      [
+        "Ġm",
+        "ed"
+      ],
+      [
+        "Ġd",
+        "am"
+      ],
+      [
+        "Ġg",
+        "l"
+      ],
+      [
+        "Ġf",
+        "ine"
+      ],
+      [
+        "an",
+        "cakes"
+      ],
+      [
+        "Ġc",
+        "ase"
+      ],
+      [
+        "Ġc",
+        "are"
+      ],
+      [
+        "Ġo",
+        "ld"
+      ],
+      [
+        "es",
+        "ides"
+      ],
+      [
+        "Ġn",
+        "ice"
+      ],
+      [
+        "or",
+        "c"
+      ],
+      [
+        "or",
+        "d"
+      ],
+      [
+        "or",
+        "ror"
+      ],
+      [
+        "or",
+        "rect"
+      ],
+      [
+        "Ġp",
+        "er"
+      ],
+      [
+        "Ġp",
+        "ri"
+      ],
+      [
+        "Ġp",
+        "ancakes"
+      ],
+      [
+        "ar",
+        "y"
+      ],
+      [
+        "ĠT",
+        "ake"
+      ],
+      [
+        "at",
+        "ed"
+      ],
+      [
+        "Ġh",
+        "urt"
+      ],
+      [
+        "ĠY",
+        "ol"
+      ],
+      [
+        "Ġon",
+        "ce"
+      ],
+      [
+        "om",
+        "ise"
+      ],
+      [
+        "Ġme",
+        "ant"
+      ],
+      [
+        "Ġha",
+        "rd"
+      ],
+      [
+        "ell",
+        "o"
+      ],
+      [
+        "Ġdo",
+        "ing"
+      ],
+      [
+        "Ġe",
+        "l"
+      ],
+      [
+        "Ġe",
+        "ar"
+      ],
+      [
+        "Ġe",
+        "ach"
+      ],
+      [
+        "ĠM",
+        "on"
+      ],
+      [
+        "ĠM",
+        "ay"
+      ],
+      [
+        "Ġsh",
+        "oot"
+      ],
+      [
+        "ĠA",
+        "ny"
+      ],
+      [
+        "ĠB",
+        "e"
+      ],
+      [
+        "ĠB",
+        "esides"
+      ],
+      [
+        "Ġyour",
+        "s"
+      ],
+      [
+        "Ġyour",
+        "self"
+      ],
+      [
+        "ĠH",
+        "orror"
+      ],
+      [
+        "ĠH",
+        "ello"
+      ],
+      [
+        "ri",
+        "ed"
+      ],
+      [
+        "ĠS",
+        "h"
+      ],
+      [
+        "ĠS",
+        "ay"
+      ],
+      [
+        "Ġst",
+        "ra"
+      ],
+      [
+        "all",
+        "ey"
+      ],
+      [
+        "ill",
+        "ion"
+      ],
+      [
+        "Ġkn",
+        "ew"
+      ],
+      [
+        "ro",
+        "p"
+      ],
+      [
+        "Ġget",
+        "t"
+      ],
+      [
+        "Ġman",
+        "y"
+      ],
+      [
+        "ĠG",
+        "ot"
+      ],
+      [
+        "ion",
+        "s"
+      ],
+      [
+        "Ġse",
+        "en"
+      ],
+      [
+        "ra",
+        "in"
+      ],
+      [
+        "Ġright",
+        "eous"
+      ],
+      [
+        "Ġat",
+        "t"
+      ],
+      [
+        "Ġshe",
+        "pherd"
+      ],
+      [
+        "Ġwor",
+        "d"
+      ],
+      [
+        "Ġany",
+        "body"
+      ],
+      [
+        "Ġsu",
+        "gar"
+      ],
+      [
+        "Ġwould",
+        "a"
+      ],
+      [
+        "Ġbl",
+        "ood"
+      ],
+      [
+        "Ġex",
+        "act"
+      ],
+      [
+        "ber",
+        "ry"
+      ],
+      [
+        "ĠE",
+        "x"
+      ],
+      [
+        "Ġmotherfuck",
+        "ers"
+      ],
+      [
+        "Ġsa",
+        "w"
+      ],
+      [
+        "Ġqu",
+        "est"
+      ],
+      [
+        "ge",
+        "ance"
+      ],
+      [
+        "ue",
+        "berry"
+      ],
+      [
+        "um",
+        "m"
+      ],
+      [
+        "Ġcom",
+        "in"
+      ],
+      [
+        "Ġbr",
+        "other"
+      ],
+      [
+        "Ġshow",
+        "s"
+      ],
+      [
+        "res",
+        "s"
+      ],
+      [
+        "Ġfat",
+        "her"
+      ],
+      [
+        "Ġch",
+        "ill"
+      ],
+      [
+        "Ġcha",
+        "ract"
+      ],
+      [
+        "ĠMe",
+        "xic"
+      ],
+      [
+        "hu",
+        "h"
+      ],
+      [
+        "Ġmad",
+        "e"
+      ],
+      [
+        "te",
+        "en"
+      ],
+      [
+        "Ġgir",
+        "l"
+      ],
+      [
+        "orm",
+        "al"
+      ],
+      [
+        "ĠRock",
+        "y"
+      ],
+      [
+        "Ġven",
+        "geance"
+      ],
+      [
+        "Ġmed",
+        "ical"
+      ],
+      [
+        "Ġdam",
+        "n"
+      ],
+      [
+        "ĠYol",
+        "anda"
+      ],
+      [
+        "Ġcharact",
+        "er"
+      ],
+      [
+        "b",
+        "it"
+      ],
+      [
+        "b",
+        "ur"
+      ],
+      [
+        "c",
+        "o"
+      ],
+      [
+        "c",
+        "ha"
+      ],
+      [
+        "c",
+        "om"
+      ],
+      [
+        "c",
+        "ess"
+      ],
+      [
+        "d",
+        "er"
+      ],
+      [
+        "e",
+        "c"
+      ],
+      [
+        "e",
+        "al"
+      ],
+      [
+        "f",
+        "t"
+      ],
+      [
+        "f",
+        "in"
+      ],
+      [
+        "f",
+        "ta"
+      ],
+      [
+        "i",
+        "re"
+      ],
+      [
+        "i",
+        "an"
+      ],
+      [
+        "m",
+        "it"
+      ],
+      [
+        "o",
+        "e"
+      ],
+      [
+        "o",
+        "ons"
+      ],
+      [
+        "p",
+        "in"
+      ],
+      [
+        "t",
+        "il"
+      ],
+      [
+        "u",
+        "ri"
+      ],
+      [
+        "w",
+        "ood"
+      ],
+      [
+        "Ġ",
+        "es"
+      ],
+      [
+        "Ġ",
+        "ill"
+      ],
+      [
+        "Ġ",
+        "ra"
+      ],
+      [
+        "Ġt",
+        "w"
+      ],
+      [
+        "Ġw",
+        "ell"
+      ],
+      [
+        "Ġs",
+        "c"
+      ],
+      [
+        "Ġs",
+        "l"
+      ],
+      [
+        "Ġs",
+        "y"
+      ],
+      [
+        "Ġs",
+        "er"
+      ],
+      [
+        "re",
+        "ad"
+      ],
+      [
+        "ha",
+        "d"
+      ],
+      [
+        "it",
+        "ion"
+      ],
+      [
+        "Ġb",
+        "um"
+      ],
+      [
+        "Ġb",
+        "ox"
+      ],
+      [
+        "Ġm",
+        "akes"
+      ],
+      [
+        "Ġm",
+        "illion"
+      ],
+      [
+        "Ġd",
+        "ou"
+      ],
+      [
+        "Ġd",
+        "is"
+      ],
+      [
+        "Ġd",
+        "ark"
+      ],
+      [
+        "Ġd",
+        "ream"
+      ],
+      [
+        "Ġf",
+        "ar"
+      ],
+      [
+        "Ġf",
+        "our"
+      ],
+      [
+        "Ġf",
+        "reak"
+      ],
+      [
+        "er",
+        "al"
+      ],
+      [
+        "an",
+        "g"
+      ],
+      [
+        "is",
+        "on"
+      ],
+      [
+        "Ġc",
+        "r"
+      ],
+      [
+        "Ġc",
+        "ho"
+      ],
+      [
+        "Ġc",
+        "op"
+      ],
+      [
+        "Ġc",
+        "han"
+      ],
+      [
+        "Ġc",
+        "aught"
+      ],
+      [
+        "Ġo",
+        "pen"
+      ],
+      [
+        "Ġl",
+        "ay"
+      ],
+      [
+        "ĠW",
+        "ould"
+      ],
+      [
+        "Ġn",
+        "ormal"
+      ],
+      [
+        "Ġp",
+        "art"
+      ],
+      [
+        "Ġhe",
+        "ad"
+      ],
+      [
+        "Ġin",
+        "ter"
+      ],
+      [
+        "ĠT",
+        "V"
+      ],
+      [
+        "ĠT",
+        "o"
+      ],
+      [
+        "ĠT",
+        "han"
+      ],
+      [
+        "ĠT",
+        "ony"
+      ],
+      [
+        "ing",
+        "o"
+      ],
+      [
+        "at",
+        "her"
+      ],
+      [
+        "Ġbe",
+        "g"
+      ],
+      [
+        "Ġh",
+        "old"
+      ],
+      [
+        "id",
+        "ent"
+      ],
+      [
+        "ut",
+        "es"
+      ],
+      [
+        "Ġha",
+        "ng"
+      ],
+      [
+        "Ġha",
+        "fta"
+      ],
+      [
+        "Ġdo",
+        "or"
+      ],
+      [
+        "ĠB",
+        "ur"
+      ],
+      [
+        "ĠB",
+        "ora"
+      ],
+      [
+        "ĠH",
+        "oney"
+      ],
+      [
+        "ĠH",
+        "ave"
+      ],
+      [
+        "ĠN",
+        "aw"
+      ],
+      [
+        "ĠS",
+        "p"
+      ],
+      [
+        "Ġwas",
+        "n"
+      ],
+      [
+        "im",
+        "al"
+      ],
+      [
+        "if",
+        "ic"
+      ],
+      [
+        "Ġst",
+        "ay"
+      ],
+      [
+        "Ġan",
+        "imal"
+      ],
+      [
+        "ĠD",
+        "addy"
+      ],
+      [
+        "Ġli",
+        "ve"
+      ],
+      [
+        "st",
+        "a"
+      ],
+      [
+        "st",
+        "on"
+      ],
+      [
+        "Ġwit",
+        "ness"
+      ],
+      [
+        "Ġre",
+        "g"
+      ],
+      [
+        "Ġre",
+        "ady"
+      ],
+      [
+        "ĠC",
+        "h"
+      ],
+      [
+        "ĠG",
+        "et"
+      ],
+      [
+        "ag",
+        "es"
+      ],
+      [
+        "ĠF",
+        "l"
+      ],
+      [
+        "ĠF",
+        "ive"
+      ],
+      [
+        "Ġno",
+        "body"
+      ],
+      [
+        "il",
+        "y"
+      ],
+      [
+        "un",
+        "n"
+      ],
+      [
+        "Ġse",
+        "lf"
+      ],
+      [
+        "ta",
+        "in"
+      ],
+      [
+        "ta",
+        "ble"
+      ],
+      [
+        "ĠR",
+        "a"
+      ],
+      [
+        "ĠR",
+        "ingo"
+      ],
+      [
+        "qu",
+        "or"
+      ],
+      [
+        "Ġde",
+        "fin"
+      ],
+      [
+        "Ġthink",
+        "in"
+      ],
+      [
+        "Ġpl",
+        "ac"
+      ],
+      [
+        "Ġtell",
+        "in"
+      ],
+      [
+        "Ġbl",
+        "ow"
+      ],
+      [
+        "ĠE",
+        "very"
+      ],
+      [
+        "Ġmotherfuck",
+        "in"
+      ],
+      [
+        "Ġcould",
+        "a"
+      ],
+      [
+        "Ġle",
+        "ft"
+      ],
+      [
+        "Ġhapp",
+        "y"
+      ],
+      [
+        "Ġkill",
+        "ed"
+      ],
+      [
+        "ci",
+        "al"
+      ],
+      [
+        "ĠK",
+        "n"
+      ],
+      [
+        "Ġcou",
+        "nt"
+      ],
+      [
+        "Ġjo",
+        "k"
+      ],
+      [
+        "Ġpr",
+        "omise"
+      ],
+      [
+        "ite",
+        "ly"
+      ],
+      [
+        "Ġspe",
+        "cial"
+      ],
+      [
+        "Ġch",
+        "ick"
+      ],
+      [
+        "ĠMar",
+        "vin"
+      ],
+      [
+        "Ġnoth",
+        "ing"
+      ],
+      [
+        "Ġmin",
+        "utes"
+      ],
+      [
+        "Ġfif",
+        "teen"
+      ],
+      [
+        "Ġtast",
+        "e"
+      ],
+      [
+        "Ġmay",
+        "be"
+      ],
+      [
+        "Ġdi",
+        "v"
+      ],
+      [
+        "Ġfe",
+        "et"
+      ],
+      [
+        "Ġple",
+        "as"
+      ],
+      [
+        "av",
+        "or"
+      ],
+      [
+        "ĠUn",
+        "cle"
+      ],
+      [
+        "ien",
+        "ne"
+      ],
+      [
+        "ĠWin",
+        "ston"
+      ],
+      [
+        "Ġpers",
+        "onal"
+      ],
+      [
+        "Ġdoll",
+        "ars"
+      ],
+      [
+        "ĠFab",
+        "ienne"
+      ],
+      [
+        "Ġtou",
+        "ch"
+      ],
+      [
+        "Ġtak",
+        "in"
+      ],
+      [
+        "Ġstra",
+        "ight"
+      ],
+      [
+        "Ġquest",
+        "ion"
+      ],
+      [
+        "bur",
+        "gers"
+      ],
+      [
+        "uri",
+        "ous"
+      ],
+      [
+        "Ġdefin",
+        "itely"
+      ],
+      [
+        "Ġplac",
+        "es"
+      ],
+      [
+        "?",
+        "\""
+      ],
+      [
+        "a",
+        "ul"
+      ],
+      [
+        "b",
+        "t"
+      ],
+      [
+        "b",
+        "oy"
+      ],
+      [
+        "b",
+        "ab"
+      ],
+      [
+        "b",
+        "ye"
+      ],
+      [
+        "c",
+        "hen"
+      ],
+      [
+        "c",
+        "hed"
+      ],
+      [
+        "d",
+        "e"
+      ],
+      [
+        "d",
+        "addy"
+      ],
+      [
+        "e",
+        "ad"
+      ],
+      [
+        "e",
+        "ren"
+      ],
+      [
+        "f",
+        "ather"
+      ],
+      [
+        "g",
+        "rand"
+      ],
+      [
+        "h",
+        "h"
+      ],
+      [
+        "i",
+        "b"
+      ],
+      [
+        "i",
+        "ed"
+      ],
+      [
+        "i",
+        "red"
+      ],
+      [
+        "m",
+        "a"
+      ],
+      [
+        "m",
+        "o"
+      ],
+      [
+        "m",
+        "an"
+      ],
+      [
+        "m",
+        "or"
+      ],
+      [
+        "m",
+        "ent"
+      ],
+      [
+        "m",
+        "are"
+      ],
+      [
+        "p",
+        "art"
+      ],
+      [
+        "p",
+        "ark"
+      ],
+      [
+        "r",
+        "an"
+      ],
+      [
+        "s",
+        "wer"
+      ],
+      [
+        "s",
+        "mare"
+      ],
+      [
+        "u",
+        "i"
+      ],
+      [
+        "u",
+        "ff"
+      ],
+      [
+        "y",
+        "a"
+      ],
+      [
+        "z",
+        "y"
+      ],
+      [
+        "Ġ",
+        "1"
+      ],
+      [
+        "Ġ",
+        "z"
+      ],
+      [
+        "Ġ",
+        "ent"
+      ],
+      [
+        "Ġ",
+        "ust"
+      ],
+      [
+        "Ġt",
+        "ong"
+      ],
+      [
+        "Ġt",
+        "able"
+      ],
+      [
+        "he",
+        "ad"
+      ],
+      [
+        "ou",
+        "nder"
+      ],
+      [
+        "Ġa",
+        "c"
+      ],
+      [
+        "Ġa",
+        "part"
+      ],
+      [
+        "Ġw",
+        "in"
+      ],
+      [
+        "Ġw",
+        "ar"
+      ],
+      [
+        "Ġs",
+        "k"
+      ],
+      [
+        "Ġs",
+        "on"
+      ],
+      [
+        "Ġs",
+        "en"
+      ],
+      [
+        "Ġs",
+        "il"
+      ],
+      [
+        "Ġs",
+        "ign"
+      ],
+      [
+        "Ġs",
+        "ittin"
+      ],
+      [
+        "Ġs",
+        "ix"
+      ],
+      [
+        "re",
+        "ci"
+      ],
+      [
+        "on",
+        "ight"
+      ],
+      [
+        "Ġy",
+        "es"
+      ],
+      [
+        "it",
+        "ies"
+      ],
+      [
+        "it",
+        "chen"
+      ],
+      [
+        "Ġb",
+        "es"
+      ],
+      [
+        "Ġb",
+        "ot"
+      ],
+      [
+        "Ġb",
+        "ar"
+      ],
+      [
+        "Ġb",
+        "est"
+      ],
+      [
+        "Ġb",
+        "ody"
+      ],
+      [
+        "Ġb",
+        "rain"
+      ],
+      [
+        "Ġm",
+        "ot"
+      ],
+      [
+        "Ġm",
+        "at"
+      ],
+      [
+        "Ġm",
+        "ine"
+      ],
+      [
+        "Ġm",
+        "ark"
+      ],
+      [
+        "Ġd",
+        "an"
+      ],
+      [
+        "Ġd",
+        "es"
+      ],
+      [
+        "Ġd",
+        "unn"
+      ],
+      [
+        "Ġf",
+        "ore"
+      ],
+      [
+        "Ġf",
+        "unny"
+      ],
+      [
+        "Ġf",
+        "avor"
+      ],
+      [
+        "Ġc",
+        "he"
+      ],
+      [
+        "Ġc",
+        "ame"
+      ],
+      [
+        "Ġc",
+        "up"
+      ],
+      [
+        "Ġc",
+        "amp"
+      ],
+      [
+        "nd",
+        "red"
+      ],
+      [
+        "Ġto",
+        "we"
+      ],
+      [
+        "Ġto",
+        "wn"
+      ],
+      [
+        "Ġl",
+        "ate"
+      ],
+      [
+        "ĠW",
+        "hich"
+      ],
+      [
+        "ĠW",
+        "hile"
+      ],
+      [
+        "ĠW",
+        "had"
+      ],
+      [
+        "Ġp",
+        "il"
+      ],
+      [
+        "Ġp",
+        "os"
+      ],
+      [
+        "Ġp",
+        "ath"
+      ],
+      [
+        "ar",
+        "ter"
+      ],
+      [
+        "Ġhe",
+        "ro"
+      ],
+      [
+        "as",
+        "ter"
+      ],
+      [
+        "ĠT",
+        "r"
+      ],
+      [
+        "at",
+        "ing"
+      ],
+      [
+        "Ġbe",
+        "er"
+      ],
+      [
+        "Ġh",
+        "id"
+      ],
+      [
+        "id",
+        "ge"
+      ],
+      [
+        "Ġme",
+        "et"
+      ],
+      [
+        "Ġme",
+        "mor"
+      ],
+      [
+        "ut",
+        "h"
+      ],
+      [
+        "Ġdo",
+        "g"
+      ],
+      [
+        "al",
+        "ine"
+      ],
+      [
+        "Ġe",
+        "as"
+      ],
+      [
+        "out",
+        "h"
+      ],
+      [
+        "ld",
+        "a"
+      ],
+      [
+        "ĠA",
+        "bout"
+      ],
+      [
+        "ĠA",
+        "fter"
+      ],
+      [
+        "ĠB",
+        "l"
+      ],
+      [
+        "Ġk",
+        "itchen"
+      ],
+      [
+        "ad",
+        "io"
+      ],
+      [
+        "ce",
+        "pt"
+      ],
+      [
+        "ĠH",
+        "oll"
+      ],
+      [
+        "ri",
+        "c"
+      ],
+      [
+        "ĠS",
+        "ee"
+      ],
+      [
+        "ĠS",
+        "orry"
+      ],
+      [
+        "Ġwe",
+        "ar"
+      ],
+      [
+        "Ġwe",
+        "ak"
+      ],
+      [
+        "Ġwas",
+        "h"
+      ],
+      [
+        "Ġmy",
+        "self"
+      ],
+      [
+        "Ġst",
+        "ri"
+      ],
+      [
+        "Ġan",
+        "other"
+      ],
+      [
+        "ent",
+        "y"
+      ],
+      [
+        "ĠD",
+        "an"
+      ],
+      [
+        "Ġli",
+        "quor"
+      ],
+      [
+        "Ġre",
+        "s"
+      ],
+      [
+        "Ġre",
+        "ad"
+      ],
+      [
+        "Ġgon",
+        "e"
+      ],
+      [
+        "Ġfor",
+        "g"
+      ],
+      [
+        "ĠJ",
+        "oe"
+      ],
+      [
+        "Ġne",
+        "w"
+      ],
+      [
+        "Ġne",
+        "cess"
+      ],
+      [
+        "ir",
+        "ty"
+      ],
+      [
+        "ĠG",
+        "o"
+      ],
+      [
+        "ĠG",
+        "ive"
+      ],
+      [
+        "il",
+        "ity"
+      ],
+      [
+        "op",
+        "e"
+      ],
+      [
+        "Ġse",
+        "c"
+      ],
+      [
+        "Ġse",
+        "x"
+      ],
+      [
+        "pp",
+        "er"
+      ],
+      [
+        "ĠP",
+        "retty"
+      ],
+      [
+        "ĠP",
+        "ounder"
+      ],
+      [
+        "ra",
+        "id"
+      ],
+      [
+        "ĠR",
+        "ed"
+      ],
+      [
+        "ĠR",
+        "oy"
+      ],
+      [
+        "qu",
+        "el"
+      ],
+      [
+        "Ġor",
+        "der"
+      ],
+      [
+        "Ġso",
+        "on"
+      ],
+      [
+        "Ġso",
+        "ap"
+      ],
+      [
+        "ĠHe",
+        "re"
+      ],
+      [
+        "Ġwatch",
+        "in"
+      ],
+      [
+        "ol",
+        "o"
+      ],
+      [
+        "ool",
+        "idge"
+      ],
+      [
+        "Ġbl",
+        "ueberry"
+      ],
+      [
+        "Ġex",
+        "pect"
+      ],
+      [
+        "Ġex",
+        "per"
+      ],
+      [
+        "ĠTh",
+        "ree"
+      ],
+      [
+        "dam",
+        "mit"
+      ],
+      [
+        "Ġsome",
+        "body"
+      ],
+      [
+        "Ġlook",
+        "in"
+      ],
+      [
+        "Ġlook",
+        "ing"
+      ],
+      [
+        "Ġneed",
+        "le"
+      ],
+      [
+        "Ġcould",
+        "n"
+      ],
+      [
+        "Ġpro",
+        "bab"
+      ],
+      [
+        "Ġr",
+        "ing"
+      ],
+      [
+        "Ġr",
+        "adio"
+      ],
+      [
+        "dy",
+        "a"
+      ],
+      [
+        "Ġlo",
+        "st"
+      ],
+      [
+        "ren",
+        "aline"
+      ],
+      [
+        "ĠGod",
+        "damn"
+      ],
+      [
+        "way",
+        "s"
+      ],
+      [
+        "Ġal",
+        "ways"
+      ],
+      [
+        "Ġtoo",
+        "k"
+      ],
+      [
+        "Ġproblem",
+        "s"
+      ],
+      [
+        "Ġgi",
+        "ven"
+      ],
+      [
+        "Ġgi",
+        "vin"
+      ],
+      [
+        "for",
+        "table"
+      ],
+      [
+        "Ġv",
+        "alley"
+      ],
+      [
+        "Ġtr",
+        "uth"
+      ],
+      [
+        "Ġmo",
+        "ve"
+      ],
+      [
+        "Ġmo",
+        "st"
+      ],
+      [
+        "Ġnig",
+        "gers"
+      ],
+      [
+        "ud",
+        "dy"
+      ],
+      [
+        "Ġspe",
+        "ak"
+      ],
+      [
+        "Ġcha",
+        "r"
+      ],
+      [
+        "ĠMar",
+        "ily"
+      ],
+      [
+        "ĠNot",
+        "h"
+      ],
+      [
+        "Ġsm",
+        "art"
+      ],
+      [
+        "Ġcont",
+        "est"
+      ],
+      [
+        "Ġhas",
+        "h"
+      ],
+      [
+        "Ġstop",
+        "ped"
+      ],
+      [
+        "ĠFor",
+        "ce"
+      ],
+      [
+        "Ġwork",
+        "ed"
+      ],
+      [
+        "Ġbuy",
+        "s"
+      ],
+      [
+        "Ġbank",
+        "s"
+      ],
+      [
+        "Ġmin",
+        "ute"
+      ],
+      [
+        "Ġrob",
+        "ber"
+      ],
+      [
+        "Ġdiff",
+        "ere"
+      ],
+      [
+        "Ġdiff",
+        "eren"
+      ],
+      [
+        "Ġapp",
+        "reci"
+      ],
+      [
+        "Ġacc",
+        "ount"
+      ],
+      [
+        "Ġacc",
+        "ident"
+      ],
+      [
+        "Ġgrand",
+        "father"
+      ],
+      [
+        "Ġple",
+        "ase"
+      ],
+      [
+        "Ġstor",
+        "y"
+      ],
+      [
+        "ere",
+        "st"
+      ],
+      [
+        "vent",
+        "ion"
+      ],
+      [
+        "Ġad",
+        "renaline"
+      ],
+      [
+        "Ġbur",
+        "ger"
+      ],
+      [
+        "Ġgar",
+        "age"
+      ],
+      [
+        "Ġpo",
+        "int"
+      ],
+      [
+        "Ġstore",
+        "s"
+      ],
+      [
+        "ĠQu",
+        "arter"
+      ],
+      [
+        "Ġim",
+        "p"
+      ],
+      [
+        "Ġte",
+        "le"
+      ],
+      [
+        "Ġwall",
+        "ets"
+      ],
+      [
+        "Ġbed",
+        "room"
+      ],
+      [
+        "Ġball",
+        "park"
+      ],
+      [
+        "Ġbull",
+        "ets"
+      ],
+      [
+        "Ġmom",
+        "ent"
+      ],
+      [
+        "Ġpier",
+        "ce"
+      ],
+      [
+        "Ġhu",
+        "ndred"
+      ],
+      [
+        "Ġstick",
+        "in"
+      ],
+      [
+        "Ġen",
+        "ough"
+      ],
+      [
+        "Ġty",
+        "ran"
+      ],
+      [
+        "Ġgl",
+        "ass"
+      ],
+      [
+        "Ġel",
+        "se"
+      ],
+      [
+        "Ġear",
+        "th"
+      ],
+      [
+        "ĠBe",
+        "cause"
+      ],
+      [
+        "Ġexact",
+        "ly"
+      ],
+      [
+        "Ġser",
+        "ious"
+      ],
+      [
+        "Ġdou",
+        "bt"
+      ],
+      [
+        "Ġdark",
+        "ness"
+      ],
+      [
+        "ĠBur",
+        "ger"
+      ],
+      [
+        "Ġwitness",
+        "ed"
+      ],
+      [
+        "Ġreg",
+        "ister"
+      ],
+      [
+        "Ġself",
+        "ish"
+      ],
+      [
+        "ĠRa",
+        "quel"
+      ],
+      [
+        "grand",
+        "daddy"
+      ],
+      [
+        "smare",
+        "lda"
+      ],
+      [
+        "Ġust",
+        "a"
+      ],
+      [
+        "Ġtong",
+        "ue"
+      ],
+      [
+        "Ġapart",
+        "ment"
+      ],
+      [
+        "Ġdan",
+        "ger"
+      ],
+      [
+        "Ġdunn",
+        "o"
+      ],
+      [
+        "Ġtowe",
+        "l"
+      ],
+      [
+        "ĠWhad",
+        "dya"
+      ],
+      [
+        "Ġpil",
+        "ot"
+      ],
+      [
+        "Ġnecess",
+        "ary"
+      ],
+      [
+        "ĠRoy",
+        "ale"
+      ],
+      [
+        "Ġprobab",
+        "ly"
+      ],
+      [
+        "ĠMarily",
+        "n"
+      ],
+      [
+        "Ġdiffere",
+        "nt"
+      ],
+      [
+        "Ġtyran",
+        "ny"
+      ],
+      [
+        "0",
+        "0"
+      ],
+      [
+        "1",
+        "7"
+      ],
+      [
+        "C",
+        "a"
+      ],
+      [
+        "T",
+        "he"
+      ],
+      [
+        "V",
+        "in"
+      ],
+      [
+        "a",
+        "i"
+      ],
+      [
+        "a",
+        "il"
+      ],
+      [
+        "a",
+        "hu"
+      ],
+      [
+        "b",
+        "y"
+      ],
+      [
+        "b",
+        "and"
+      ],
+      [
+        "b",
+        "age"
+      ],
+      [
+        "c",
+        "l"
+      ],
+      [
+        "c",
+        "on"
+      ],
+      [
+        "c",
+        "ing"
+      ],
+      [
+        "c",
+        "us"
+      ],
+      [
+        "c",
+        "ri"
+      ],
+      [
+        "c",
+        "hes"
+      ],
+      [
+        "d",
+        "ay"
+      ],
+      [
+        "d",
+        "ad"
+      ],
+      [
+        "d",
+        "oll"
+      ],
+      [
+        "e",
+        "ver"
+      ],
+      [
+        "e",
+        "ak"
+      ],
+      [
+        "e",
+        "qu"
+      ],
+      [
+        "f",
+        "ect"
+      ],
+      [
+        "f",
+        "ied"
+      ],
+      [
+        "f",
+        "raid"
+      ],
+      [
+        "g",
+        "un"
+      ],
+      [
+        "h",
+        "it"
+      ],
+      [
+        "h",
+        "ind"
+      ],
+      [
+        "h",
+        "ite"
+      ],
+      [
+        "i",
+        "et"
+      ],
+      [
+        "i",
+        "est"
+      ],
+      [
+        "j",
+        "ect"
+      ],
+      [
+        "k",
+        "en"
+      ],
+      [
+        "k",
+        "ie"
+      ],
+      [
+        "l",
+        "t"
+      ],
+      [
+        "l",
+        "im"
+      ],
+      [
+        "l",
+        "and"
+      ],
+      [
+        "l",
+        "ish"
+      ],
+      [
+        "m",
+        "p"
+      ],
+      [
+        "m",
+        "et"
+      ],
+      [
+        "m",
+        "ers"
+      ],
+      [
+        "n",
+        "ed"
+      ],
+      [
+        "o",
+        "f"
+      ],
+      [
+        "o",
+        "ly"
+      ],
+      [
+        "p",
+        "hone"
+      ],
+      [
+        "r",
+        "ad"
+      ],
+      [
+        "r",
+        "own"
+      ],
+      [
+        "s",
+        "a"
+      ],
+      [
+        "s",
+        "o"
+      ],
+      [
+        "s",
+        "u"
+      ],
+      [
+        "s",
+        "ol"
+      ],
+      [
+        "t",
+        "o"
+      ],
+      [
+        "t",
+        "un"
+      ],
+      [
+        "t",
+        "wo"
+      ],
+      [
+        "u",
+        "g"
+      ],
+      [
+        "u",
+        "ally"
+      ],
+      [
+        "v",
+        "ed"
+      ],
+      [
+        "v",
+        "ill"
+      ],
+      [
+        "v",
+        "ie"
+      ],
+      [
+        "x",
+        "t"
+      ],
+      [
+        "y",
+        "es"
+      ],
+      [
+        "y",
+        "cle"
+      ],
+      [
+        "Ġ",
+        "ve"
+      ],
+      [
+        "Ġ",
+        "ri"
+      ],
+      [
+        "Ġt",
+        "ri"
+      ],
+      [
+        "Ġt",
+        "rou"
+      ],
+      [
+        "Ġt",
+        "onight"
+      ],
+      [
+        "ou",
+        "n"
+      ],
+      [
+        "Ġa",
+        "r"
+      ],
+      [
+        "Ġa",
+        "fter"
+      ],
+      [
+        "Ġa",
+        "fraid"
+      ],
+      [
+        "in",
+        "s"
+      ],
+      [
+        "in",
+        "ny"
+      ],
+      [
+        "in",
+        "ish"
+      ],
+      [
+        "Ġw",
+        "ish"
+      ],
+      [
+        "Ġs",
+        "et"
+      ],
+      [
+        "Ġs",
+        "ides"
+      ],
+      [
+        "re",
+        "at"
+      ],
+      [
+        "on",
+        "z"
+      ],
+      [
+        "on",
+        "rad"
+      ],
+      [
+        "Ġy",
+        "ell"
+      ],
+      [
+        "Ġb",
+        "as"
+      ],
+      [
+        "Ġb",
+        "ro"
+      ],
+      [
+        "Ġb",
+        "ir"
+      ],
+      [
+        "Ġb",
+        "ath"
+      ],
+      [
+        "Ġb",
+        "oss"
+      ],
+      [
+        "Ġm",
+        "ag"
+      ],
+      [
+        "Ġm",
+        "ess"
+      ],
+      [
+        "Ġm",
+        "outh"
+      ],
+      [
+        "Ġthe",
+        "e"
+      ],
+      [
+        "Ġthe",
+        "se"
+      ],
+      [
+        "Ġd",
+        "y"
+      ],
+      [
+        "Ġd",
+        "in"
+      ],
+      [
+        "Ġd",
+        "ig"
+      ],
+      [
+        "Ġd",
+        "ur"
+      ],
+      [
+        "Ġd",
+        "est"
+      ],
+      [
+        "Ġd",
+        "ate"
+      ],
+      [
+        "Ġd",
+        "ance"
+      ],
+      [
+        "Ġg",
+        "en"
+      ],
+      [
+        "Ġg",
+        "ook"
+      ],
+      [
+        "Ġg",
+        "ra"
+      ],
+      [
+        "Ġg",
+        "our"
+      ],
+      [
+        "Ġg",
+        "ang"
+      ],
+      [
+        "Ġf",
+        "l"
+      ],
+      [
+        "Ġf",
+        "ing"
+      ],
+      [
+        "Ġf",
+        "ood"
+      ],
+      [
+        "Ġf",
+        "ox"
+      ],
+      [
+        "Ġf",
+        "ound"
+      ],
+      [
+        "Ġf",
+        "lo"
+      ],
+      [
+        "Ġf",
+        "urious"
+      ],
+      [
+        "Ġf",
+        "aul"
+      ],
+      [
+        "Ġf",
+        "inish"
+      ],
+      [
+        "ll",
+        "ect"
+      ],
+      [
+        "er",
+        "v"
+      ],
+      [
+        "er",
+        "tain"
+      ],
+      [
+        "an",
+        "ese"
+      ],
+      [
+        "an",
+        "gar"
+      ],
+      [
+        "is",
+        "k"
+      ],
+      [
+        "Ġc",
+        "as"
+      ],
+      [
+        "Ġc",
+        "at"
+      ],
+      [
+        "Ġc",
+        "ro"
+      ],
+      [
+        "Ġc",
+        "ir"
+      ],
+      [
+        "Ġc",
+        "ab"
+      ],
+      [
+        "Ġc",
+        "ap"
+      ],
+      [
+        "Ġc",
+        "orrect"
+      ],
+      [
+        "Ġc",
+        "ertain"
+      ],
+      [
+        "Ġo",
+        "l"
+      ],
+      [
+        "es",
+        "us"
+      ],
+      [
+        "Ġto",
+        "p"
+      ],
+      [
+        "Ġto",
+        "ss"
+      ],
+      [
+        "ot",
+        "ect"
+      ],
+      [
+        "ot",
+        "hes"
+      ],
+      [
+        "Ġl",
+        "ess"
+      ],
+      [
+        "Ġl",
+        "ady"
+      ],
+      [
+        "ĠW",
+        "ar"
+      ],
+      [
+        "ĠW",
+        "ill"
+      ],
+      [
+        "ĠW",
+        "anna"
+      ],
+      [
+        "Ġn",
+        "am"
+      ],
+      [
+        "Ġn",
+        "ight"
+      ],
+      [
+        "or",
+        "k"
+      ],
+      [
+        "Ġp",
+        "a"
+      ],
+      [
+        "Ġp",
+        "ig"
+      ],
+      [
+        "Ġp",
+        "ack"
+      ],
+      [
+        "Ġp",
+        "ass"
+      ],
+      [
+        "Ġp",
+        "unch"
+      ],
+      [
+        "Ġp",
+        "iss"
+      ],
+      [
+        "Ġp",
+        "oss"
+      ],
+      [
+        "ar",
+        "is"
+      ],
+      [
+        "ar",
+        "con"
+      ],
+      [
+        "Ġth",
+        "row"
+      ],
+      [
+        "Ġth",
+        "rown"
+      ],
+      [
+        "en",
+        "ce"
+      ],
+      [
+        "as",
+        "hed"
+      ],
+      [
+        "Ġin",
+        "st"
+      ],
+      [
+        "Ġin",
+        "side"
+      ],
+      [
+        "Ġin",
+        "equ"
+      ],
+      [
+        "ed",
+        "eral"
+      ],
+      [
+        "us",
+        "h"
+      ],
+      [
+        "us",
+        "band"
+      ],
+      [
+        "le",
+        "ase"
+      ],
+      [
+        "Ġbe",
+        "c"
+      ],
+      [
+        "Ġbe",
+        "ing"
+      ],
+      [
+        "Ġbe",
+        "hind"
+      ],
+      [
+        "Ġh",
+        "ill"
+      ],
+      [
+        "Ġh",
+        "our"
+      ],
+      [
+        "Ġh",
+        "oney"
+      ],
+      [
+        "Ġh",
+        "usband"
+      ],
+      [
+        "om",
+        "ers"
+      ],
+      [
+        "id",
+        "er"
+      ],
+      [
+        "Ġha",
+        "lf"
+      ],
+      [
+        "Ġe",
+        "ye"
+      ],
+      [
+        "Ġe",
+        "yes"
+      ],
+      [
+        "ĠM",
+        "er"
+      ],
+      [
+        "ĠM",
+        "ong"
+      ],
+      [
+        "Ġsh",
+        "op"
+      ],
+      [
+        "ĠA",
+        "un"
+      ],
+      [
+        "ĠB",
+        "unny"
+      ],
+      [
+        "ĠB",
+        "ible"
+      ],
+      [
+        "Ġk",
+        "ick"
+      ],
+      [
+        "Ġk",
+        "angar"
+      ],
+      [
+        "ĠH",
+        "i"
+      ],
+      [
+        "ĠH",
+        "ea"
+      ],
+      [
+        "ĠH",
+        "ond"
+      ],
+      [
+        "ĠS",
+        "e"
+      ],
+      [
+        "ĠS",
+        "om"
+      ],
+      [
+        "Ġst",
+        "ab"
+      ],
+      [
+        "Ġst",
+        "uff"
+      ],
+      [
+        "Ġst",
+        "eak"
+      ],
+      [
+        "Ġas",
+        "ide"
+      ],
+      [
+        "Ġan",
+        "ger"
+      ],
+      [
+        "Ġan",
+        "swer"
+      ],
+      [
+        "ĠD",
+        "eal"
+      ],
+      [
+        "st",
+        "em"
+      ],
+      [
+        "Ġre",
+        "sta"
+      ],
+      [
+        "ust",
+        "omers"
+      ],
+      [
+        "ro",
+        "y"
+      ],
+      [
+        "ĠJ",
+        "ack"
+      ],
+      [
+        "ĠJ",
+        "ap"
+      ],
+      [
+        "ĠJ",
+        "ew"
+      ],
+      [
+        "ĠJ",
+        "esus"
+      ],
+      [
+        "em",
+        "pt"
+      ],
+      [
+        "Ġman",
+        "ag"
+      ],
+      [
+        "ĠC",
+        "ome"
+      ],
+      [
+        "ĠC",
+        "orrect"
+      ],
+      [
+        "ĠC",
+        "oolidge"
+      ],
+      [
+        "ĠC",
+        "onrad"
+      ],
+      [
+        "ĠG",
+        "inny"
+      ],
+      [
+        "ag",
+        "ed"
+      ],
+      [
+        "ĠF",
+        "onz"
+      ],
+      [
+        "ĠO",
+        "D"
+      ],
+      [
+        "ĠO",
+        "n"
+      ],
+      [
+        "il",
+        "k"
+      ],
+      [
+        "il",
+        "t"
+      ],
+      [
+        "ind",
+        "ed"
+      ],
+      [
+        "pp",
+        "les"
+      ],
+      [
+        "ĠP",
+        "aris"
+      ],
+      [
+        "ĠP",
+        "lease"
+      ],
+      [
+        "ur",
+        "n"
+      ],
+      [
+        "ur",
+        "s"
+      ],
+      [
+        "ur",
+        "ants"
+      ],
+      [
+        "ĠL",
+        "ord"
+      ],
+      [
+        "ĠNo",
+        "body"
+      ],
+      [
+        "Ġwant",
+        "ed"
+      ],
+      [
+        "ul",
+        "ar"
+      ],
+      [
+        "ul",
+        "ip"
+      ],
+      [
+        "ĠR",
+        "es"
+      ],
+      [
+        "ĠR",
+        "ight"
+      ],
+      [
+        "Ġde",
+        "al"
+      ],
+      [
+        "Ġde",
+        "ath"
+      ],
+      [
+        "Ġde",
+        "li"
+      ],
+      [
+        "ĠV",
+        "eg"
+      ],
+      [
+        "Ġass",
+        "es"
+      ],
+      [
+        "Ġare",
+        "n"
+      ],
+      [
+        "Ġwho",
+        "le"
+      ],
+      [
+        "Ġwor",
+        "ry"
+      ],
+      [
+        "Ġwor",
+        "th"
+      ],
+      [
+        "Ġpl",
+        "ay"
+      ],
+      [
+        "Ġpl",
+        "ate"
+      ],
+      [
+        "oy",
+        "d"
+      ],
+      [
+        "ee",
+        "p"
+      ],
+      [
+        "otherfuck",
+        "er"
+      ],
+      [
+        "Ġex",
+        "ec"
+      ],
+      [
+        "Ġex",
+        "cept"
+      ],
+      [
+        "Ġoff",
+        "end"
+      ],
+      [
+        "ĠE",
+        "ng"
+      ],
+      [
+        "ĠE",
+        "ze"
+      ],
+      [
+        "Ġlook",
+        "ed"
+      ],
+      [
+        "Ġqu",
+        "ite"
+      ],
+      [
+        "Ġthing",
+        "s"
+      ],
+      [
+        "Ġint",
+        "erest"
+      ],
+      [
+        "Ġshould",
+        "a"
+      ],
+      [
+        "ĠU",
+        "u"
+      ],
+      [
+        "Ġr",
+        "isk"
+      ],
+      [
+        "um",
+        "p"
+      ],
+      [
+        "Ġcom",
+        "p"
+      ],
+      [
+        "Ġle",
+        "ad"
+      ],
+      [
+        "Ġmass",
+        "ages"
+      ],
+      [
+        "Ġfind",
+        "s"
+      ],
+      [
+        "Ġco",
+        "ld"
+      ],
+      [
+        "Ġco",
+        "st"
+      ],
+      [
+        "Ġco",
+        "llect"
+      ],
+      [
+        "Ġshot",
+        "gun"
+      ],
+      [
+        "Ġrem",
+        "inded"
+      ],
+      [
+        "ĠK",
+        "ahu"
+      ],
+      [
+        "ĠK",
+        "eep"
+      ],
+      [
+        "ren",
+        "ch"
+      ],
+      [
+        "Ġcou",
+        "n"
+      ],
+      [
+        "ĠDo",
+        "es"
+      ],
+      [
+        "Ġjo",
+        "ke"
+      ],
+      [
+        "ist",
+        "en"
+      ],
+      [
+        "Ġpr",
+        "otect"
+      ],
+      [
+        "Ġal",
+        "ive"
+      ],
+      [
+        "Ġsp",
+        "l"
+      ],
+      [
+        "Ġhappen",
+        "s"
+      ],
+      [
+        "Ġgi",
+        "ves"
+      ],
+      [
+        "Ġgi",
+        "ving"
+      ],
+      [
+        "ĠWho",
+        "a"
+      ],
+      [
+        "for",
+        "tun"
+      ],
+      [
+        "Ġmo",
+        "vie"
+      ],
+      [
+        "ple",
+        "ase"
+      ],
+      [
+        "ud",
+        "i"
+      ],
+      [
+        "Ġspe",
+        "c"
+      ],
+      [
+        "Ġboy",
+        "s"
+      ],
+      [
+        "Ġeven",
+        "ing"
+      ],
+      [
+        "Ġsm",
+        "oke"
+      ],
+      [
+        "Ġcont",
+        "in"
+      ],
+      [
+        "Ġpie",
+        "ces"
+      ],
+      [
+        "ĠFor",
+        "get"
+      ],
+      [
+        "Ġevery",
+        "thing"
+      ],
+      [
+        "Ġwr",
+        "ist"
+      ],
+      [
+        "Ġmet",
+        "ric"
+      ],
+      [
+        "Ġfif",
+        "ty"
+      ],
+      [
+        "Ġlea",
+        "vin"
+      ],
+      [
+        "ute",
+        "ly"
+      ],
+      [
+        "ĠSt",
+        "op"
+      ],
+      [
+        "Ġun",
+        "less"
+      ],
+      [
+        "less",
+        "ed"
+      ],
+      [
+        "Ġtast",
+        "y"
+      ],
+      [
+        "Ġgrand",
+        "dad"
+      ],
+      [
+        "Ġpop",
+        "pa"
+      ],
+      [
+        "Ġstor",
+        "age"
+      ],
+      [
+        "iz",
+        "ed"
+      ],
+      [
+        "vent",
+        "ure"
+      ],
+      [
+        "Ġad",
+        "venture"
+      ],
+      [
+        "Ġgar",
+        "bage"
+      ],
+      [
+        "Ġcl",
+        "othes"
+      ],
+      [
+        "Ġpo",
+        "ison"
+      ],
+      [
+        "Ġret",
+        "ard"
+      ],
+      [
+        "Ġseem",
+        "s"
+      ],
+      [
+        "Ġseem",
+        "ed"
+      ],
+      [
+        "Ġtry",
+        "in"
+      ],
+      [
+        "Ġab",
+        "sol"
+      ],
+      [
+        "Ġball",
+        "oons"
+      ],
+      [
+        "Ġmom",
+        "ma"
+      ],
+      [
+        "Ġdri",
+        "ve"
+      ],
+      [
+        "Ġluck",
+        "y"
+      ],
+      [
+        "Ġpier",
+        "cing"
+      ],
+      [
+        "Ġ2",
+        "5"
+      ],
+      [
+        "orc",
+        "ed"
+      ],
+      [
+        "orc",
+        "ycle"
+      ],
+      [
+        "ĠMon",
+        "ro"
+      ],
+      [
+        "ĠMon",
+        "ster"
+      ],
+      [
+        "ĠMay",
+        "be"
+      ],
+      [
+        "ĠSh",
+        "ut"
+      ],
+      [
+        "Ġgett",
+        "in"
+      ],
+      [
+        "Ġgett",
+        "ing"
+      ],
+      [
+        "Ġatt",
+        "empt"
+      ],
+      [
+        "Ġblood",
+        "y"
+      ],
+      [
+        "umm",
+        "y"
+      ],
+      [
+        "Ġbrother",
+        "s"
+      ],
+      [
+        "bit",
+        "ch"
+      ],
+      [
+        "com",
+        "fortable"
+      ],
+      [
+        "Ġsy",
+        "stem"
+      ],
+      [
+        "Ġbox",
+        "ing"
+      ],
+      [
+        "Ġcr",
+        "ashed"
+      ],
+      [
+        "Ġcho",
+        "pper"
+      ],
+      [
+        "Ġcop",
+        "s"
+      ],
+      [
+        "Ġpart",
+        "ner"
+      ],
+      [
+        "ĠThan",
+        "ks"
+      ],
+      [
+        "ĠFl",
+        "oyd"
+      ],
+      [
+        "ĠEvery",
+        "body"
+      ],
+      [
+        "Ġcount",
+        "ry"
+      ],
+      [
+        "Ġjok",
+        "es"
+      ],
+      [
+        "Ġdiv",
+        "orced"
+      ],
+      [
+        "Ġpleas",
+        "ure"
+      ],
+      [
+        "Ġpersonal",
+        "ity"
+      ],
+      [
+        "mo",
+        "st"
+      ],
+      [
+        "Ġsk",
+        "ull"
+      ],
+      [
+        "Ġbes",
+        "et"
+      ],
+      [
+        "Ġmot",
+        "orcycle"
+      ],
+      [
+        "Ġmark",
+        "er"
+      ],
+      [
+        "Ġdes",
+        "cri"
+      ],
+      [
+        "Ġfore",
+        "ver"
+      ],
+      [
+        "Ġpos",
+        "ition"
+      ],
+      [
+        "Ġmemor",
+        "ized"
+      ],
+      [
+        "ĠHoll",
+        "y"
+      ],
+      [
+        "Ġstri",
+        "ke"
+      ],
+      [
+        "olo",
+        "id"
+      ],
+      [
+        "Ġchar",
+        "ity"
+      ],
+      [
+        "Ġcontest",
+        "ants"
+      ],
+      [
+        "Ġrobber",
+        "y"
+      ],
+      [
+        "Ġdifferen",
+        "ce"
+      ],
+      [
+        "Ġtele",
+        "phone"
+      ],
+      [
+        "Ca",
+        "use"
+      ],
+      [
+        "Vin",
+        "cent"
+      ],
+      [
+        "doll",
+        "ar"
+      ],
+      [
+        "kie",
+        "l"
+      ],
+      [
+        "Ġtrou",
+        "ble"
+      ],
+      [
+        "Ġbath",
+        "room"
+      ],
+      [
+        "Ġmag",
+        "ic"
+      ],
+      [
+        "Ġdur",
+        "ing"
+      ],
+      [
+        "Ġdest",
+        "roy"
+      ],
+      [
+        "Ġgour",
+        "met"
+      ],
+      [
+        "Ġflo",
+        "or"
+      ],
+      [
+        "Ġfaul",
+        "t"
+      ],
+      [
+        "Ġcat",
+        "ch"
+      ],
+      [
+        "Ġpass",
+        "age"
+      ],
+      [
+        "Ġinequ",
+        "ities"
+      ],
+      [
+        "ĠMong",
+        "oloid"
+      ],
+      [
+        "ĠAun",
+        "t"
+      ],
+      [
+        "Ġkangar",
+        "oo"
+      ],
+      [
+        "ĠHea",
+        "ven"
+      ],
+      [
+        "ĠHond",
+        "a"
+      ],
+      [
+        "ĠJap",
+        "anese"
+      ],
+      [
+        "Ġdeli",
+        "ver"
+      ],
+      [
+        "ĠVeg",
+        "a"
+      ],
+      [
+        "ĠEng",
+        "lish"
+      ],
+      [
+        "ĠEze",
+        "kiel"
+      ],
+      [
+        "ĠKahu",
+        "na"
+      ],
+      [
+        "fortun",
+        "ate"
+      ],
+      [
+        "Ġabsol",
+        "utely"
+      ],
+      [
+        "Ġdescri",
+        "be"
+      ],
+      [
+        "3",
+        "0"
+      ],
+      [
+        "D",
+        "onal"
+      ],
+      [
+        "D",
+        "ead"
+      ],
+      [
+        "E",
+        "smarelda"
+      ],
+      [
+        "F",
+        "ox"
+      ],
+      [
+        "I",
+        "A"
+      ],
+      [
+        "O",
+        "N"
+      ],
+      [
+        "U",
+        "N"
+      ],
+      [
+        "a",
+        "x"
+      ],
+      [
+        "a",
+        "us"
+      ],
+      [
+        "b",
+        "ed"
+      ],
+      [
+        "b",
+        "ill"
+      ],
+      [
+        "b",
+        "bit"
+      ],
+      [
+        "c",
+        "ou"
+      ],
+      [
+        "c",
+        "ed"
+      ],
+      [
+        "c",
+        "use"
+      ],
+      [
+        "d",
+        "d"
+      ],
+      [
+        "d",
+        "o"
+      ],
+      [
+        "d",
+        "en"
+      ],
+      [
+        "d",
+        "ing"
+      ],
+      [
+        "e",
+        "red"
+      ],
+      [
+        "e",
+        "ase"
+      ],
+      [
+        "f",
+        "ive"
+      ],
+      [
+        "f",
+        "ant"
+      ],
+      [
+        "g",
+        "l"
+      ],
+      [
+        "g",
+        "o"
+      ],
+      [
+        "g",
+        "ed"
+      ],
+      [
+        "g",
+        "ing"
+      ],
+      [
+        "g",
+        "ry"
+      ],
+      [
+        "g",
+        "est"
+      ],
+      [
+        "h",
+        "ic"
+      ],
+      [
+        "h",
+        "ouse"
+      ],
+      [
+        "i",
+        "ar"
+      ],
+      [
+        "i",
+        "ke"
+      ],
+      [
+        "i",
+        "gh"
+      ],
+      [
+        "i",
+        "ven"
+      ],
+      [
+        "i",
+        "pe"
+      ],
+      [
+        "k",
+        "in"
+      ],
+      [
+        "l",
+        "ed"
+      ],
+      [
+        "l",
+        "ing"
+      ],
+      [
+        "l",
+        "ster"
+      ],
+      [
+        "m",
+        "e"
+      ],
+      [
+        "m",
+        "m"
+      ],
+      [
+        "m",
+        "ed"
+      ],
+      [
+        "m",
+        "ore"
+      ],
+      [
+        "m",
+        "other"
+      ],
+      [
+        "m",
+        "burgers"
+      ],
+      [
+        "n",
+        "es"
+      ],
+      [
+        "n",
+        "ow"
+      ],
+      [
+        "n",
+        "am"
+      ],
+      [
+        "o",
+        "i"
+      ],
+      [
+        "o",
+        "an"
+      ],
+      [
+        "o",
+        "ffee"
+      ],
+      [
+        "p",
+        "it"
+      ],
+      [
+        "r",
+        "ing"
+      ],
+      [
+        "r",
+        "ist"
+      ],
+      [
+        "r",
+        "ite"
+      ],
+      [
+        "s",
+        "h"
+      ],
+      [
+        "s",
+        "i"
+      ],
+      [
+        "s",
+        "ive"
+      ],
+      [
+        "t",
+        "om"
+      ],
+      [
+        "t",
+        "ist"
+      ],
+      [
+        "u",
+        "ly"
+      ],
+      [
+        "u",
+        "ca"
+      ],
+      [
+        "v",
+        "is"
+      ],
+      [
+        "v",
+        "ol"
+      ],
+      [
+        "w",
+        "here"
+      ],
+      [
+        "w",
+        "hile"
+      ],
+      [
+        "y",
+        "ou"
+      ],
+      [
+        "y",
+        "ing"
+      ],
+      [
+        "Ġ",
+        "-"
+      ],
+      [
+        "Ġ",
+        "."
+      ],
+      [
+        "Ġ",
+        "3"
+      ],
+      [
+        "Ġ",
+        "4"
+      ],
+      [
+        "Ġ",
+        "8"
+      ],
+      [
+        "Ġ",
+        "9"
+      ],
+      [
+        "Ġ",
+        "hat"
+      ],
+      [
+        "Ġt",
+        "en"
+      ],
+      [
+        "Ġt",
+        "ra"
+      ],
+      [
+        "Ġt",
+        "ick"
+      ],
+      [
+        "Ġt",
+        "end"
+      ],
+      [
+        "Ġt",
+        "rop"
+      ],
+      [
+        "Ġt",
+        "rain"
+      ],
+      [
+        "Ġt",
+        "urn"
+      ],
+      [
+        "Ġt",
+        "ummy"
+      ],
+      [
+        "he",
+        "ther"
+      ],
+      [
+        "Ġa",
+        "head"
+      ],
+      [
+        "in",
+        "en"
+      ],
+      [
+        "in",
+        "ce"
+      ],
+      [
+        "in",
+        "ci"
+      ],
+      [
+        "Ġw",
+        "et"
+      ],
+      [
+        "Ġw",
+        "ed"
+      ],
+      [
+        "Ġw",
+        "om"
+      ],
+      [
+        "Ġw",
+        "ore"
+      ],
+      [
+        "Ġw",
+        "ine"
+      ],
+      [
+        "Ġw",
+        "hile"
+      ],
+      [
+        "Ġw",
+        "oke"
+      ],
+      [
+        "ĠI",
+        "ng"
+      ],
+      [
+        "Ġs",
+        "w"
+      ],
+      [
+        "Ġs",
+        "at"
+      ],
+      [
+        "Ġs",
+        "ell"
+      ],
+      [
+        "Ġs",
+        "ink"
+      ],
+      [
+        "Ġs",
+        "ca"
+      ],
+      [
+        "Ġs",
+        "ide"
+      ],
+      [
+        "Ġs",
+        "iz"
+      ],
+      [
+        "re",
+        "w"
+      ],
+      [
+        "re",
+        "et"
+      ],
+      [
+        "re",
+        "ast"
+      ],
+      [
+        "re",
+        "pa"
+      ],
+      [
+        "on",
+        "na"
+      ],
+      [
+        "on",
+        "able"
+      ],
+      [
+        "ha",
+        "se"
+      ],
+      [
+        "Ġy",
+        "eah"
+      ],
+      [
+        "it",
+        "ch"
+      ],
+      [
+        "it",
+        "ive"
+      ],
+      [
+        "Ġb",
+        "o"
+      ],
+      [
+        "Ġb",
+        "u"
+      ],
+      [
+        "Ġb",
+        "le"
+      ],
+      [
+        "Ġb",
+        "al"
+      ],
+      [
+        "Ġb",
+        "ars"
+      ],
+      [
+        "Ġb",
+        "rou"
+      ],
+      [
+        "Ġb",
+        "are"
+      ],
+      [
+        "Ġb",
+        "ought"
+      ],
+      [
+        "Ġb",
+        "ui"
+      ],
+      [
+        "Ġb",
+        "uddy"
+      ],
+      [
+        "Ġb",
+        "reast"
+      ],
+      [
+        "Ġm",
+        "ust"
+      ],
+      [
+        "Ġm",
+        "iss"
+      ],
+      [
+        "Ġm",
+        "ister"
+      ],
+      [
+        "Ġm",
+        "aster"
+      ],
+      [
+        "Ġd",
+        "ry"
+      ],
+      [
+        "Ġd",
+        "ick"
+      ],
+      [
+        "Ġd",
+        "are"
+      ],
+      [
+        "Ġd",
+        "addy"
+      ],
+      [
+        "Ġd",
+        "rop"
+      ],
+      [
+        "Ġd",
+        "read"
+      ],
+      [
+        "Ġd",
+        "irty"
+      ],
+      [
+        "Ġg",
+        "r"
+      ],
+      [
+        "Ġg",
+        "as"
+      ],
+      [
+        "Ġf",
+        "ut"
+      ],
+      [
+        "Ġf",
+        "am"
+      ],
+      [
+        "Ġf",
+        "ew"
+      ],
+      [
+        "Ġf",
+        "ix"
+      ],
+      [
+        "Ġf",
+        "ire"
+      ],
+      [
+        "Ġf",
+        "ederal"
+      ],
+      [
+        "ll",
+        "way"
+      ],
+      [
+        "er",
+        "y"
+      ],
+      [
+        "er",
+        "ic"
+      ],
+      [
+        "er",
+        "fect"
+      ],
+      [
+        "an",
+        "y"
+      ],
+      [
+        "an",
+        "ish"
+      ],
+      [
+        "an",
+        "ned"
+      ],
+      [
+        "an",
+        "oi"
+      ],
+      [
+        "is",
+        "it"
+      ],
+      [
+        "is",
+        "co"
+      ],
+      [
+        "is",
+        "fied"
+      ],
+      [
+        "Ġc",
+        "on"
+      ],
+      [
+        "Ġc",
+        "or"
+      ],
+      [
+        "Ġc",
+        "ow"
+      ],
+      [
+        "Ġc",
+        "oo"
+      ],
+      [
+        "Ġc",
+        "ell"
+      ],
+      [
+        "Ġc",
+        "ra"
+      ],
+      [
+        "Ġc",
+        "hi"
+      ],
+      [
+        "Ġc",
+        "orn"
+      ],
+      [
+        "Ġc",
+        "ity"
+      ],
+      [
+        "Ġc",
+        "ons"
+      ],
+      [
+        "Ġc",
+        "ream"
+      ],
+      [
+        "Ġc",
+        "urious"
+      ],
+      [
+        "Ġc",
+        "ease"
+      ],
+      [
+        "nd",
+        "o"
+      ],
+      [
+        "nd",
+        "ry"
+      ],
+      [
+        "Ġo",
+        "ak"
+      ],
+      [
+        "Ġo",
+        "pin"
+      ],
+      [
+        "Ġo",
+        "dd"
+      ],
+      [
+        "Ġto",
+        "get"
+      ],
+      [
+        "Ġl",
+        "a"
+      ],
+      [
+        "Ġl",
+        "oy"
+      ],
+      [
+        "Ġl",
+        "isten"
+      ],
+      [
+        "Ġl",
+        "ying"
+      ],
+      [
+        "Ġl",
+        "inen"
+      ],
+      [
+        "ĠW",
+        "or"
+      ],
+      [
+        "ĠW",
+        "ant"
+      ],
+      [
+        "ĠW",
+        "ake"
+      ],
+      [
+        "ĠW",
+        "hite"
+      ],
+      [
+        "Ġn",
+        "i"
+      ],
+      [
+        "Ġn",
+        "ut"
+      ],
+      [
+        "Ġn",
+        "erv"
+      ],
+      [
+        "ck",
+        "s"
+      ],
+      [
+        "Ġit",
+        "s"
+      ],
+      [
+        "or",
+        "s"
+      ],
+      [
+        "or",
+        "row"
+      ],
+      [
+        "or",
+        "ks"
+      ],
+      [
+        "Ġp",
+        "h"
+      ],
+      [
+        "Ġp",
+        "ar"
+      ],
+      [
+        "Ġp",
+        "en"
+      ],
+      [
+        "Ġp",
+        "al"
+      ],
+      [
+        "Ġp",
+        "ur"
+      ],
+      [
+        "Ġp",
+        "ock"
+      ],
+      [
+        "Ġp",
+        "ull"
+      ],
+      [
+        "Ġp",
+        "res"
+      ],
+      [
+        "Ġp",
+        "repa"
+      ],
+      [
+        "ar",
+        "ch"
+      ],
+      [
+        "ar",
+        "red"
+      ],
+      [
+        "ar",
+        "ia"
+      ],
+      [
+        "ar",
+        "ian"
+      ],
+      [
+        "Ġth",
+        "ous"
+      ],
+      [
+        "Ġth",
+        "res"
+      ],
+      [
+        "Ġth",
+        "rew"
+      ],
+      [
+        "en",
+        "nes"
+      ],
+      [
+        "as",
+        "h"
+      ],
+      [
+        "as",
+        "onable"
+      ],
+      [
+        "Ġin",
+        "for"
+      ],
+      [
+        "Ġin",
+        "vention"
+      ],
+      [
+        "Ġin",
+        "ject"
+      ],
+      [
+        "Ġin",
+        "su"
+      ],
+      [
+        "Ġin",
+        "fant"
+      ],
+      [
+        "Ġin",
+        "vol"
+      ],
+      [
+        "ĠT",
+        "ow"
+      ],
+      [
+        "ĠT",
+        "oo"
+      ],
+      [
+        "ĠT",
+        "om"
+      ],
+      [
+        "ĠT",
+        "ry"
+      ],
+      [
+        "ĠT",
+        "ol"
+      ],
+      [
+        "ĠT",
+        "wo"
+      ],
+      [
+        "ĠT",
+        "ulip"
+      ],
+      [
+        "ĠT",
+        "ennes"
+      ],
+      [
+        "us",
+        "ions"
+      ],
+      [
+        "le",
+        "wood"
+      ],
+      [
+        "at",
+        "in"
+      ],
+      [
+        "at",
+        "ter"
+      ],
+      [
+        "at",
+        "io"
+      ],
+      [
+        "at",
+        "aria"
+      ],
+      [
+        "Ġbe",
+        "at"
+      ],
+      [
+        "Ġbe",
+        "au"
+      ],
+      [
+        "oo",
+        "h"
+      ],
+      [
+        "Ġh",
+        "un"
+      ],
+      [
+        "Ġh",
+        "os"
+      ],
+      [
+        "Ġh",
+        "ora"
+      ],
+      [
+        "Ġh",
+        "oly"
+      ],
+      [
+        "Ġh",
+        "igh"
+      ],
+      [
+        "ĠY",
+        "a"
+      ],
+      [
+        "ĠY",
+        "ep"
+      ],
+      [
+        "id",
+        "s"
+      ],
+      [
+        "ut",
+        "if"
+      ],
+      [
+        "Ġha",
+        "vin"
+      ],
+      [
+        "Ġha",
+        "mburgers"
+      ],
+      [
+        "Ġha",
+        "llway"
+      ],
+      [
+        "Ġdo",
+        "gs"
+      ],
+      [
+        "Ġe",
+        "m"
+      ],
+      [
+        "Ġe",
+        "ff"
+      ],
+      [
+        "ĠM",
+        "an"
+      ],
+      [
+        "ĠM",
+        "art"
+      ],
+      [
+        "ĠM",
+        "iss"
+      ],
+      [
+        "ĠM",
+        "otherfucker"
+      ],
+      [
+        "ĠM",
+        "IA"
+      ],
+      [
+        "ld",
+        "ing"
+      ],
+      [
+        "ld",
+        "ren"
+      ],
+      [
+        "ĠA",
+        "l"
+      ],
+      [
+        "ĠA",
+        "t"
+      ],
+      [
+        "ĠA",
+        "pples"
+      ],
+      [
+        "ĠB",
+        "ea"
+      ],
+      [
+        "ĠB",
+        "oy"
+      ],
+      [
+        "ĠB",
+        "ye"
+      ],
+      [
+        "ĠB",
+        "uddy"
+      ],
+      [
+        "ĠB",
+        "lessed"
+      ],
+      [
+        "Ġis",
+        "n"
+      ],
+      [
+        "Ġis",
+        "land"
+      ],
+      [
+        "Ġfuck",
+        "ing"
+      ],
+      [
+        "Ġk",
+        "iss"
+      ],
+      [
+        "Ġk",
+        "ids"
+      ],
+      [
+        "ad",
+        "ies"
+      ],
+      [
+        "Ġdon",
+        "t"
+      ],
+      [
+        "am",
+        "burgers"
+      ],
+      [
+        "am",
+        "oan"
+      ],
+      [
+        "ĠH",
+        "old"
+      ],
+      [
+        "ĠH",
+        "anoi"
+      ],
+      [
+        "ĠH",
+        "amburgers"
+      ],
+      [
+        "ri",
+        "ate"
+      ],
+      [
+        "ĠN",
+        "eg"
+      ],
+      [
+        "ĠS",
+        "lim"
+      ],
+      [
+        "Ġwe",
+        "e"
+      ],
+      [
+        "Ġwe",
+        "ir"
+      ],
+      [
+        "im",
+        "p"
+      ],
+      [
+        "if",
+        "s"
+      ],
+      [
+        "if",
+        "t"
+      ],
+      [
+        "Ġst",
+        "ud"
+      ],
+      [
+        "Ġst",
+        "up"
+      ],
+      [
+        "Ġst",
+        "reet"
+      ],
+      [
+        "Ġst",
+        "arred"
+      ],
+      [
+        "ill",
+        "a"
+      ],
+      [
+        "ent",
+        "ions"
+      ],
+      [
+        "ĠD",
+        "isco"
+      ],
+      [
+        "Ġgo",
+        "ld"
+      ],
+      [
+        "Ġli",
+        "ght"
+      ],
+      [
+        "Ġj",
+        "u"
+      ],
+      [
+        "Ġj",
+        "ud"
+      ],
+      [
+        "Ġkn",
+        "ife"
+      ],
+      [
+        "st",
+        "ers"
+      ],
+      [
+        "Ġre",
+        "d"
+      ],
+      [
+        "Ġre",
+        "st"
+      ],
+      [
+        "Ġre",
+        "act"
+      ],
+      [
+        "Ġre",
+        "asonable"
+      ],
+      [
+        "Ġfor",
+        "ty"
+      ],
+      [
+        "ust",
+        "r"
+      ],
+      [
+        "ro",
+        "l"
+      ],
+      [
+        "Ġknow",
+        "s"
+      ],
+      [
+        "em",
+        "ent"
+      ],
+      [
+        "em",
+        "ember"
+      ],
+      [
+        "em",
+        "pl"
+      ],
+      [
+        "Ġwith",
+        "out"
+      ],
+      [
+        "Ġget",
+        "s"
+      ],
+      [
+        "se",
+        "e"
+      ],
+      [
+        "se",
+        "at"
+      ],
+      [
+        "Ġup",
+        "ho"
+      ],
+      [
+        "ir",
+        "t"
+      ],
+      [
+        "ho",
+        "ld"
+      ],
+      [
+        "Ġnot",
+        "ice"
+      ],
+      [
+        "ĠC",
+        "ho"
+      ],
+      [
+        "ĠC",
+        "oke"
+      ],
+      [
+        "ĠC",
+        "ount"
+      ],
+      [
+        "ĠC",
+        "ustomers"
+      ],
+      [
+        "ĠC",
+        "offee"
+      ],
+      [
+        "ĠG",
+        "er"
+      ],
+      [
+        "ĠG",
+        "arcon"
+      ],
+      [
+        "ĠG",
+        "imp"
+      ],
+      [
+        "ĠF",
+        "irst"
+      ],
+      [
+        "ĠF",
+        "rench"
+      ],
+      [
+        "ĠO",
+        "oo"
+      ],
+      [
+        "ĠO",
+        "pen"
+      ],
+      [
+        "ĠO",
+        "ui"
+      ],
+      [
+        "Ġno",
+        "se"
+      ],
+      [
+        "ter",
+        "s"
+      ],
+      [
+        "Ġbut",
+        "ter"
+      ],
+      [
+        "ĠWe",
+        "re"
+      ],
+      [
+        "pp",
+        "in"
+      ],
+      [
+        "ĠP",
+        "r"
+      ],
+      [
+        "ĠP",
+        "ot"
+      ],
+      [
+        "ĠP",
+        "ut"
+      ],
+      [
+        "ĠP",
+        "ep"
+      ],
+      [
+        "ĠP",
+        "erfect"
+      ],
+      [
+        "ĠL",
+        "e"
+      ],
+      [
+        "ĠL",
+        "ake"
+      ],
+      [
+        "ĠL",
+        "ance"
+      ],
+      [
+        "ĠL",
+        "ew"
+      ],
+      [
+        "ĠL",
+        "ike"
+      ],
+      [
+        "ra",
+        "bbit"
+      ],
+      [
+        "Ġwant",
+        "s"
+      ],
+      [
+        "ĠR",
+        "e"
+      ],
+      [
+        "ĠR",
+        "emember"
+      ],
+      [
+        "Ġde",
+        "c"
+      ],
+      [
+        "ĠV",
+        "alley"
+      ],
+      [
+        "ĠV",
+        "iet"
+      ],
+      [
+        "Ġass",
+        "ho"
+      ],
+      [
+        "th",
+        "right"
+      ],
+      [
+        "itt",
+        "y"
+      ],
+      [
+        "itt",
+        "ing"
+      ],
+      [
+        "Ġor",
+        "al"
+      ],
+      [
+        "Ġwat",
+        "er"
+      ],
+      [
+        "Ġwat",
+        "ched"
+      ],
+      [
+        "Ġwat",
+        "ches"
+      ],
+      [
+        "Ġsay",
+        "s"
+      ],
+      [
+        "Ġgood",
+        "bye"
+      ],
+      [
+        "Ġwho",
+        "a"
+      ],
+      [
+        "Ġwor",
+        "ried"
+      ],
+      [
+        "Ġany",
+        "way"
+      ],
+      [
+        "Ġany",
+        "more"
+      ],
+      [
+        "ick",
+        "ly"
+      ],
+      [
+        "Ġtalk",
+        "ed"
+      ],
+      [
+        "Ġcall",
+        "s"
+      ],
+      [
+        "Ġcall",
+        "in"
+      ],
+      [
+        "Ġpl",
+        "anned"
+      ],
+      [
+        "ĠDon",
+        "de"
+      ],
+      [
+        "Ġsu",
+        "b"
+      ],
+      [
+        "Ġwatch",
+        "ing"
+      ],
+      [
+        "pe",
+        "ze"
+      ],
+      [
+        "Ġbl",
+        "ank"
+      ],
+      [
+        "Ġcar",
+        "ry"
+      ],
+      [
+        "Ġex",
+        "pen"
+      ],
+      [
+        "Ġex",
+        "pl"
+      ],
+      [
+        "ĠE",
+        "l"
+      ],
+      [
+        "ĠE",
+        "smarelda"
+      ],
+      [
+        "Ġus",
+        "ed"
+      ],
+      [
+        "Ġsome",
+        "where"
+      ],
+      [
+        "nt",
+        "il"
+      ],
+      [
+        "oot",
+        "ies"
+      ],
+      [
+        "Ġsa",
+        "us"
+      ],
+      [
+        "Ġqu",
+        "ilt"
+      ],
+      [
+        "Ġback",
+        "seat"
+      ],
+      [
+        "Ġpro",
+        "d"
+      ],
+      [
+        "Ġint",
+        "entions"
+      ],
+      [
+        "Ġr",
+        "ide"
+      ],
+      [
+        "Ġr",
+        "oom"
+      ],
+      [
+        "um",
+        "b"
+      ],
+      [
+        "Ġro",
+        "ll"
+      ],
+      [
+        "Ġcom",
+        "for"
+      ],
+      [
+        "ation",
+        "s"
+      ],
+      [
+        "ĠJul",
+        "ie"
+      ],
+      [
+        "get",
+        "arian"
+      ],
+      [
+        "Ġfind",
+        "er"
+      ],
+      [
+        "Ġbit",
+        "e"
+      ],
+      [
+        "Ġgre",
+        "w"
+      ],
+      [
+        "Ġfight",
+        "er"
+      ],
+      [
+        "Ġjo",
+        "int"
+      ],
+      [
+        "ĠGod",
+        "dammit"
+      ],
+      [
+        "ap",
+        "ataria"
+      ],
+      [
+        "ist",
+        "ic"
+      ],
+      [
+        "Ġpr",
+        "ide"
+      ],
+      [
+        "Ġpr",
+        "ison"
+      ],
+      [
+        "Ġpr",
+        "inci"
+      ],
+      [
+        "Ġask",
+        "in"
+      ],
+      [
+        "Ġask",
+        "ed"
+      ],
+      [
+        "be",
+        "an"
+      ],
+      [
+        "ock",
+        "i"
+      ],
+      [
+        "Ġal",
+        "right"
+      ],
+      [
+        "Ġal",
+        "ong"
+      ],
+      [
+        "Ġal",
+        "most"
+      ],
+      [
+        "Ġsp",
+        "ot"
+      ],
+      [
+        "Ġsp",
+        "read"
+      ],
+      [
+        "ox",
+        "vill"
+      ],
+      [
+        "we",
+        "et"
+      ],
+      [
+        "Ġke",
+        "y"
+      ],
+      [
+        "Ġke",
+        "pt"
+      ],
+      [
+        "Ġthan",
+        "k"
+      ],
+      [
+        "Ġlot",
+        "sa"
+      ],
+      [
+        "ĠLook",
+        "s"
+      ],
+      [
+        "Ġv",
+        "isit"
+      ],
+      [
+        "Ġtr",
+        "ans"
+      ],
+      [
+        "Ġtr",
+        "aged"
+      ],
+      [
+        "Ġtr",
+        "uly"
+      ],
+      [
+        "Ġsha",
+        "re"
+      ],
+      [
+        "Ġfriend",
+        "ly"
+      ],
+      [
+        "Ġhelp",
+        "s"
+      ],
+      [
+        "Ġeat",
+        "in"
+      ],
+      [
+        "ĠAm",
+        "eric"
+      ],
+      [
+        "Ġreal",
+        "iz"
+      ],
+      [
+        "ĠQ",
+        "ue"
+      ],
+      [
+        "Ġwait",
+        "ing"
+      ],
+      [
+        "Ġmorn",
+        "in"
+      ],
+      [
+        "Ġcont",
+        "rol"
+      ],
+      [
+        "Ġcont",
+        "empl"
+      ],
+      [
+        "ĠChe",
+        "ck"
+      ],
+      [
+        "Ġclean",
+        "s"
+      ],
+      [
+        "Ġbuy",
+        "in"
+      ],
+      [
+        "Ġfif",
+        "th"
+      ],
+      [
+        "Ġtom",
+        "orrow"
+      ],
+      [
+        "ĠSt",
+        "ill"
+      ],
+      [
+        "Ġun",
+        "lo"
+      ],
+      [
+        "Ġun",
+        "comfortable"
+      ],
+      [
+        "Ġun",
+        "fortunate"
+      ],
+      [
+        "Ġrob",
+        "bed"
+      ],
+      [
+        "Ġkeep",
+        "er"
+      ],
+      [
+        "Ġapp",
+        "les"
+      ],
+      [
+        "Ġapp",
+        "rop"
+      ],
+      [
+        "Ġmad",
+        "man"
+      ],
+      [
+        "Ġmir",
+        "ror"
+      ],
+      [
+        "Ġdi",
+        "rect"
+      ],
+      [
+        "Ġgrand",
+        "mother"
+      ],
+      [
+        "Ġfe",
+        "ces"
+      ],
+      [
+        "Ġfe",
+        "lt"
+      ],
+      [
+        "Ġlau",
+        "ndry"
+      ],
+      [
+        "Ġbell",
+        "ies"
+      ],
+      [
+        "av",
+        "a"
+      ],
+      [
+        "lo",
+        "ve"
+      ],
+      [
+        "per",
+        "ate"
+      ],
+      [
+        "Ġfell",
+        "as"
+      ],
+      [
+        "Ġfact",
+        "or"
+      ],
+      [
+        "Ġcl",
+        "osed"
+      ],
+      [
+        "Ġthought",
+        "s"
+      ],
+      [
+        "Ġret",
+        "ired"
+      ],
+      [
+        "ract",
+        "ive"
+      ],
+      [
+        "ĠQu",
+        "it"
+      ],
+      [
+        "Ġwindow",
+        "s"
+      ],
+      [
+        "Ġab",
+        "ility"
+      ],
+      [
+        "Ġwall",
+        "et"
+      ],
+      [
+        "Ġbull",
+        "et"
+      ],
+      [
+        "Ġdri",
+        "vin"
+      ],
+      [
+        "ĠWin",
+        "ocki"
+      ],
+      [
+        "Ġpers",
+        "on"
+      ],
+      [
+        "Ġhu",
+        "h"
+      ],
+      [
+        "Ġdoll",
+        "ar"
+      ],
+      [
+        "ĠMac",
+        "Donal"
+      ],
+      [
+        "ĠAn",
+        "other"
+      ],
+      [
+        "amp",
+        "s"
+      ],
+      [
+        "ĠFuck",
+        "in"
+      ],
+      [
+        "ĠFab",
+        "by"
+      ],
+      [
+        "Ġty",
+        "pe"
+      ],
+      [
+        "Ġbag",
+        "s"
+      ],
+      [
+        "ord",
+        "ing"
+      ],
+      [
+        "Ġpri",
+        "v"
+      ],
+      [
+        "Ġpri",
+        "cks"
+      ],
+      [
+        "ĠSh",
+        "it"
+      ],
+      [
+        "Ġatt",
+        "ractive"
+      ],
+      [
+        "Ġshepherd",
+        "s"
+      ],
+      [
+        "umm",
+        "mm"
+      ],
+      [
+        "ress",
+        "es"
+      ],
+      [
+        "ress",
+        "ed"
+      ],
+      [
+        "ĠMexic",
+        "o"
+      ],
+      [
+        "ĠMexic",
+        "an"
+      ],
+      [
+        "ĠMexic",
+        "ans"
+      ],
+      [
+        "Ġdamn",
+        "ed"
+      ],
+      [
+        "Ġes",
+        "ta"
+      ],
+      [
+        "Ġill",
+        "usions"
+      ],
+      [
+        "Ġill",
+        "ustr"
+      ],
+      [
+        "Ġra",
+        "ce"
+      ],
+      [
+        "Ġtw",
+        "ist"
+      ],
+      [
+        "Ġtw",
+        "enty"
+      ],
+      [
+        "Ġsl",
+        "ight"
+      ],
+      [
+        "Ġsl",
+        "ice"
+      ],
+      [
+        "Ġbum",
+        "p"
+      ],
+      [
+        "Ġmillion",
+        "ai"
+      ],
+      [
+        "Ġchan",
+        "ged"
+      ],
+      [
+        "Ġinter",
+        "vention"
+      ],
+      [
+        "ĠThan",
+        "k"
+      ],
+      [
+        "Ġbeg",
+        "ins"
+      ],
+      [
+        "Ġhold",
+        "ing"
+      ],
+      [
+        "ĠSp",
+        "rite"
+      ],
+      [
+        "ĠSp",
+        "anish"
+      ],
+      [
+        "ific",
+        "ant"
+      ],
+      [
+        "ific",
+        "ally"
+      ],
+      [
+        "Ġanimal",
+        "s"
+      ],
+      [
+        "ĠCh",
+        "ill"
+      ],
+      [
+        "ĠCh",
+        "rist"
+      ],
+      [
+        "ĠKn",
+        "oxvill"
+      ],
+      [
+        "Ġspecial",
+        "ty"
+      ],
+      [
+        "Ġchick",
+        "en"
+      ],
+      [
+        "Ġdiv",
+        "ine"
+      ],
+      [
+        "Ġpleas",
+        "ing"
+      ],
+      [
+        "Ġ1",
+        "0"
+      ],
+      [
+        "Ġz",
+        "apataria"
+      ],
+      [
+        "Ġent",
+        "ire"
+      ],
+      [
+        "Ġent",
+        "ered"
+      ],
+      [
+        "Ġac",
+        "ro"
+      ],
+      [
+        "Ġsen",
+        "se"
+      ],
+      [
+        "Ġsil",
+        "ence"
+      ],
+      [
+        "Ġbot",
+        "h"
+      ],
+      [
+        "Ġbot",
+        "tom"
+      ],
+      [
+        "Ġmat",
+        "ter"
+      ],
+      [
+        "Ġche",
+        "ck"
+      ],
+      [
+        "ĠTr",
+        "udi"
+      ],
+      [
+        "Ġeas",
+        "y"
+      ],
+      [
+        "Ġeas",
+        "ier"
+      ],
+      [
+        "ĠBl",
+        "ood"
+      ],
+      [
+        "ĠBl",
+        "ueberry"
+      ],
+      [
+        "ĠDan",
+        "e"
+      ],
+      [
+        "Ġres",
+        "p"
+      ],
+      [
+        "Ġnew",
+        "s"
+      ],
+      [
+        "Ġsec",
+        "ret"
+      ],
+      [
+        "Ġsec",
+        "ond"
+      ],
+      [
+        "Ġsex",
+        "y"
+      ],
+      [
+        "Ġexpect",
+        "ing"
+      ],
+      [
+        "Ġexper",
+        "t"
+      ],
+      [
+        "Ġexper",
+        "ien"
+      ],
+      [
+        "ĠNoth",
+        "in"
+      ],
+      [
+        "ĠNoth",
+        "ing"
+      ],
+      [
+        "Ġappreci",
+        "ate"
+      ],
+      [
+        "Ġappreci",
+        "ated"
+      ],
+      [
+        "Ġaccident",
+        "ally"
+      ],
+      [
+        "Ġimp",
+        "oss"
+      ],
+      [
+        "Ġimp",
+        "ort"
+      ],
+      [
+        "Ġdanger",
+        "ous"
+      ],
+      [
+        "mers",
+        "et"
+      ],
+      [
+        "Ġve",
+        "getarian"
+      ],
+      [
+        "Ġtri",
+        "al"
+      ],
+      [
+        "Ġar",
+        "tist"
+      ],
+      [
+        "Ġbas",
+        "ed"
+      ],
+      [
+        "Ġbir",
+        "thright"
+      ],
+      [
+        "Ġdy",
+        "in"
+      ],
+      [
+        "Ġdin",
+        "ner"
+      ],
+      [
+        "Ġgen",
+        "eral"
+      ],
+      [
+        "Ġgook",
+        "s"
+      ],
+      [
+        "Ġgang",
+        "sters"
+      ],
+      [
+        "Ġfing",
+        "ers"
+      ],
+      [
+        "Ġcas",
+        "a"
+      ],
+      [
+        "Ġcro",
+        "ss"
+      ],
+      [
+        "Ġcir",
+        "cus"
+      ],
+      [
+        "Ġnam",
+        "es"
+      ],
+      [
+        "Ġpa",
+        "id"
+      ],
+      [
+        "Ġposs",
+        "ible"
+      ],
+      [
+        "Ġinst",
+        "ead"
+      ],
+      [
+        "Ġbec",
+        "ome"
+      ],
+      [
+        "Ġhill",
+        "bill"
+      ],
+      [
+        "ĠMer",
+        "ci"
+      ],
+      [
+        "Ġkick",
+        "in"
+      ],
+      [
+        "ĠSom",
+        "merset"
+      ],
+      [
+        "Ġresta",
+        "urants"
+      ],
+      [
+        "ĠJack",
+        "rabbit"
+      ],
+      [
+        "ĠJew",
+        "ish"
+      ],
+      [
+        "Ġmanag",
+        "er"
+      ],
+      [
+        "ĠFonz",
+        "ie"
+      ],
+      [
+        "ĠOD",
+        "ing"
+      ],
+      [
+        "ĠRes",
+        "pect"
+      ],
+      [
+        "Ġexec",
+        "ute"
+      ],
+      [
+        "Ġoffend",
+        "ed"
+      ],
+      [
+        "ump",
+        "kin"
+      ],
+      [
+        "Ġcomp",
+        "any"
+      ],
+      [
+        "Ġcost",
+        "s"
+      ],
+      [
+        "Ġshotgun",
+        "s"
+      ],
+      [
+        "Ġcoun",
+        "ter"
+      ],
+      [
+        "Ġprotect",
+        "ive"
+      ],
+      [
+        "Ġspl",
+        "it"
+      ],
+      [
+        "Ġspec",
+        "ifically"
+      ],
+      [
+        "Ġcontin",
+        "ue"
+      ],
+      [
+        "ĠMonro",
+        "e"
+      ],
+      [
+        "ĠHolly",
+        "wood"
+      ],
+      [
+        "cou",
+        "p"
+      ],
+      [
+        "lster",
+        "y"
+      ],
+      [
+        "nam",
+        "ese"
+      ],
+      [
+        "pit",
+        "al"
+      ],
+      [
+        "Ġhat",
+        "e"
+      ],
+      [
+        "Ġtra",
+        "peze"
+      ],
+      [
+        "Ġtrop",
+        "hy"
+      ],
+      [
+        "Ġturn",
+        "s"
+      ],
+      [
+        "Ġwed",
+        "ding"
+      ],
+      [
+        "Ġwom",
+        "an"
+      ],
+      [
+        "ĠIng",
+        "lewood"
+      ],
+      [
+        "Ġsca",
+        "red"
+      ],
+      [
+        "Ġsiz",
+        "es"
+      ],
+      [
+        "Ġbrou",
+        "ght"
+      ],
+      [
+        "Ġbui",
+        "lding"
+      ],
+      [
+        "Ġdread",
+        "ful"
+      ],
+      [
+        "Ġcoo",
+        "perate"
+      ],
+      [
+        "Ġcell",
+        "ular"
+      ],
+      [
+        "Ġcra",
+        "zy"
+      ],
+      [
+        "Ġchi",
+        "ldren"
+      ],
+      [
+        "Ġcons",
+        "ider"
+      ],
+      [
+        "Ġopin",
+        "ion"
+      ],
+      [
+        "Ġtoget",
+        "her"
+      ],
+      [
+        "Ġloy",
+        "al"
+      ],
+      [
+        "ĠWor",
+        "ld"
+      ],
+      [
+        "Ġnerv",
+        "ous"
+      ],
+      [
+        "Ġpock",
+        "et"
+      ],
+      [
+        "Ġprepa",
+        "red"
+      ],
+      [
+        "Ġthous",
+        "and"
+      ],
+      [
+        "Ġthres",
+        "hold"
+      ],
+      [
+        "Ġinject",
+        "ion"
+      ],
+      [
+        "Ġinsu",
+        "red"
+      ],
+      [
+        "ĠTol",
+        "uca"
+      ],
+      [
+        "ĠTennes",
+        "see"
+      ],
+      [
+        "Ġbeau",
+        "coup"
+      ],
+      [
+        "Ġhos",
+        "pital"
+      ],
+      [
+        "utif",
+        "ul"
+      ],
+      [
+        "ĠMart",
+        "in"
+      ],
+      [
+        "Ġstup",
+        "id"
+      ],
+      [
+        "Ġupho",
+        "lstery"
+      ],
+      [
+        "ĠPep",
+        "si"
+      ],
+      [
+        "ĠLew",
+        "is"
+      ],
+      [
+        "ĠViet",
+        "namese"
+      ],
+      [
+        "Ġblank",
+        "ets"
+      ],
+      [
+        "Ġexpen",
+        "sive"
+      ],
+      [
+        "Ġexpl",
+        "os"
+      ],
+      [
+        "Ġquilt",
+        "s"
+      ],
+      [
+        "Ġtraged",
+        "y"
+      ],
+      [
+        "ĠAmeric",
+        "an"
+      ],
+      [
+        "Ġcontempl",
+        "ating"
+      ],
+      [
+        "Ġunlo",
+        "ad"
+      ],
+      [
+        "Ġapprop",
+        "riate"
+      ],
+      [
+        "Ġdirect",
+        "ly"
+      ],
+      [
+        "ĠMacDonal",
+        "d"
+      ],
+      [
+        "Ġmillionai",
+        "res"
+      ],
+      [
+        "ĠKnoxvill",
+        "e"
+      ],
+      [
+        "Ġhillbill",
+        "y"
+      ],
+      [
+        "!",
+        "!"
+      ],
+      [
+        "%",
+        "."
+      ],
+      [
+        "'",
+        "!"
+      ],
+      [
+        "'",
+        "-"
+      ],
+      [
+        ".",
+        ","
+      ],
+      [
+        "1",
+        "8"
+      ],
+      [
+        "3",
+        "5"
+      ],
+      [
+        "4",
+        "5"
+      ],
+      [
+        "7",
+        "4"
+      ],
+      [
+        "7",
+        "00"
+      ],
+      [
+        "9",
+        "74"
+      ],
+      [
+        ";",
+        ","
+      ],
+      [
+        "?",
+        "..."
+      ],
+      [
+        "A",
+        "R"
+      ],
+      [
+        "A",
+        "V"
+      ],
+      [
+        "B",
+        "ed"
+      ],
+      [
+        "B",
+        "at"
+      ],
+      [
+        "C",
+        "E"
+      ],
+      [
+        "C",
+        "O"
+      ],
+      [
+        "C",
+        "T"
+      ],
+      [
+        "C",
+        "oy"
+      ],
+      [
+        "C",
+        "oolidge"
+      ],
+      [
+        "D",
+        "on"
+      ],
+      [
+        "E",
+        "R"
+      ],
+      [
+        "E",
+        "ver"
+      ],
+      [
+        "E",
+        "mp"
+      ],
+      [
+        "F",
+        "L"
+      ],
+      [
+        "F",
+        "O"
+      ],
+      [
+        "F",
+        "raid"
+      ],
+      [
+        "G",
+        "ood"
+      ],
+      [
+        "G",
+        "arcon"
+      ],
+      [
+        "G",
+        "UN"
+      ],
+      [
+        "H",
+        "E"
+      ],
+      [
+        "H",
+        "oy"
+      ],
+      [
+        "I",
+        "V"
+      ],
+      [
+        "I",
+        "t"
+      ],
+      [
+        "I",
+        "ON"
+      ],
+      [
+        "I",
+        "CT"
+      ],
+      [
+        "K",
+        "UN"
+      ],
+      [
+        "L",
+        "uck"
+      ],
+      [
+        "M",
+        "ar"
+      ],
+      [
+        "M",
+        "arsellus"
+      ],
+      [
+        "M",
+        "ember"
+      ],
+      [
+        "N",
+        "ow"
+      ],
+      [
+        "N",
+        "eal"
+      ],
+      [
+        "O",
+        "R"
+      ],
+      [
+        "O",
+        "T"
+      ],
+      [
+        "O",
+        "ne"
+      ],
+      [
+        "P",
+        "S"
+      ],
+      [
+        "P",
+        "Y"
+      ],
+      [
+        "P",
+        "ER"
+      ],
+      [
+        "R",
+        "E"
+      ],
+      [
+        "S",
+        "U"
+      ],
+      [
+        "S",
+        "amoan"
+      ],
+      [
+        "U",
+        "RE"
+      ],
+      [
+        "W",
+        "e"
+      ],
+      [
+        "a",
+        "f"
+      ],
+      [
+        "a",
+        "j"
+      ],
+      [
+        "a",
+        "ir"
+      ],
+      [
+        "a",
+        "ven"
+      ],
+      [
+        "a",
+        "ine"
+      ],
+      [
+        "a",
+        "rett"
+      ],
+      [
+        "a",
+        "hit"
+      ],
+      [
+        "a",
+        "utiful"
+      ],
+      [
+        "b",
+        "b"
+      ],
+      [
+        "b",
+        "l"
+      ],
+      [
+        "b",
+        "on"
+      ],
+      [
+        "b",
+        "ar"
+      ],
+      [
+        "b",
+        "ing"
+      ],
+      [
+        "b",
+        "at"
+      ],
+      [
+        "b",
+        "ut"
+      ],
+      [
+        "b",
+        "all"
+      ],
+      [
+        "b",
+        "ack"
+      ],
+      [
+        "b",
+        "ly"
+      ],
+      [
+        "b",
+        "ble"
+      ],
+      [
+        "b",
+        "os"
+      ],
+      [
+        "b",
+        "est"
+      ],
+      [
+        "b",
+        "ac"
+      ],
+      [
+        "b",
+        "ies"
+      ],
+      [
+        "b",
+        "ank"
+      ],
+      [
+        "b",
+        "row"
+      ],
+      [
+        "b",
+        "lessed"
+      ],
+      [
+        "b",
+        "itty"
+      ],
+      [
+        "c",
+        "he"
+      ],
+      [
+        "c",
+        "it"
+      ],
+      [
+        "c",
+        "hat"
+      ],
+      [
+        "c",
+        "an"
+      ],
+      [
+        "c",
+        "ot"
+      ],
+      [
+        "c",
+        "at"
+      ],
+      [
+        "c",
+        "ell"
+      ],
+      [
+        "c",
+        "il"
+      ],
+      [
+        "c",
+        "ise"
+      ],
+      [
+        "c",
+        "ony"
+      ],
+      [
+        "c",
+        "ated"
+      ],
+      [
+        "c",
+        "ident"
+      ],
+      [
+        "c",
+        "Coy"
+      ],
+      [
+        "d",
+        "a"
+      ],
+      [
+        "d",
+        "s"
+      ],
+      [
+        "d",
+        "ers"
+      ],
+      [
+        "d",
+        "own"
+      ],
+      [
+        "d",
+        "est"
+      ],
+      [
+        "d",
+        "ried"
+      ],
+      [
+        "d",
+        "ressed"
+      ],
+      [
+        "e",
+        "x"
+      ],
+      [
+        "e",
+        "es"
+      ],
+      [
+        "e",
+        "ar"
+      ],
+      [
+        "e",
+        "gal"
+      ],
+      [
+        "e",
+        "ather"
+      ],
+      [
+        "e",
+        "xt"
+      ],
+      [
+        "f",
+        "e"
+      ],
+      [
+        "f",
+        "l"
+      ],
+      [
+        "f",
+        "u"
+      ],
+      [
+        "f",
+        "it"
+      ],
+      [
+        "f",
+        "is"
+      ],
+      [
+        "f",
+        "am"
+      ],
+      [
+        "f",
+        "ie"
+      ],
+      [
+        "f",
+        "riend"
+      ],
+      [
+        "f",
+        "ull"
+      ],
+      [
+        "f",
+        "ire"
+      ],
+      [
+        "f",
+        "ric"
+      ],
+      [
+        "g",
+        "r"
+      ],
+      [
+        "g",
+        "u"
+      ],
+      [
+        "g",
+        "y"
+      ],
+      [
+        "g",
+        "in"
+      ],
+      [
+        "g",
+        "es"
+      ],
+      [
+        "g",
+        "le"
+      ],
+      [
+        "g",
+        "ie"
+      ],
+      [
+        "g",
+        "ir"
+      ],
+      [
+        "g",
+        "ag"
+      ],
+      [
+        "g",
+        "ra"
+      ],
+      [
+        "g",
+        "th"
+      ],
+      [
+        "g",
+        "round"
+      ],
+      [
+        "g",
+        "ical"
+      ],
+      [
+        "g",
+        "gs"
+      ],
+      [
+        "g",
+        "umm"
+      ],
+      [
+        "g",
+        "gest"
+      ],
+      [
+        "h",
+        "n"
+      ],
+      [
+        "h",
+        "is"
+      ],
+      [
+        "h",
+        "ing"
+      ],
+      [
+        "h",
+        "ous"
+      ],
+      [
+        "h",
+        "ng"
+      ],
+      [
+        "i",
+        "ot"
+      ],
+      [
+        "i",
+        "or"
+      ],
+      [
+        "i",
+        "le"
+      ],
+      [
+        "i",
+        "ld"
+      ],
+      [
+        "i",
+        "ct"
+      ],
+      [
+        "i",
+        "od"
+      ],
+      [
+        "i",
+        "ers"
+      ],
+      [
+        "i",
+        "qu"
+      ],
+      [
+        "i",
+        "ac"
+      ],
+      [
+        "i",
+        "ate"
+      ],
+      [
+        "i",
+        "ves"
+      ],
+      [
+        "i",
+        "ving"
+      ],
+      [
+        "k",
+        "es"
+      ],
+      [
+        "k",
+        "now"
+      ],
+      [
+        "l",
+        "or"
+      ],
+      [
+        "l",
+        "ve"
+      ],
+      [
+        "l",
+        "ay"
+      ],
+      [
+        "l",
+        "ook"
+      ],
+      [
+        "l",
+        "op"
+      ],
+      [
+        "l",
+        "ight"
+      ],
+      [
+        "l",
+        "ic"
+      ],
+      [
+        "l",
+        "ine"
+      ],
+      [
+        "l",
+        "ife"
+      ],
+      [
+        "l",
+        "ady"
+      ],
+      [
+        "m",
+        "s"
+      ],
+      [
+        "m",
+        "in"
+      ],
+      [
+        "m",
+        "er"
+      ],
+      [
+        "m",
+        "ly"
+      ],
+      [
+        "m",
+        "ick"
+      ],
+      [
+        "m",
+        "ation"
+      ],
+      [
+        "m",
+        "iss"
+      ],
+      [
+        "m",
+        "ans"
+      ],
+      [
+        "m",
+        "el"
+      ],
+      [
+        "m",
+        "ilk"
+      ],
+      [
+        "m",
+        "otherfucker"
+      ],
+      [
+        "n",
+        "on"
+      ],
+      [
+        "n",
+        "out"
+      ],
+      [
+        "n",
+        "ant"
+      ],
+      [
+        "n",
+        "ers"
+      ],
+      [
+        "n",
+        "ight"
+      ],
+      [
+        "n",
+        "um"
+      ],
+      [
+        "n",
+        "ard"
+      ],
+      [
+        "n",
+        "ough"
+      ],
+      [
+        "n",
+        "iqu"
+      ],
+      [
+        "o",
+        "in"
+      ],
+      [
+        "o",
+        "or"
+      ],
+      [
+        "o",
+        "ci"
+      ],
+      [
+        "o",
+        "ice"
+      ],
+      [
+        "o",
+        "gs"
+      ],
+      [
+        "o",
+        "hh"
+      ],
+      [
+        "o",
+        "ken"
+      ],
+      [
+        "o",
+        "bos"
+      ],
+      [
+        "o",
+        "gra"
+      ],
+      [
+        "o",
+        "hn"
+      ],
+      [
+        "p",
+        "s"
+      ],
+      [
+        "p",
+        "he"
+      ],
+      [
+        "p",
+        "is"
+      ],
+      [
+        "p",
+        "es"
+      ],
+      [
+        "p",
+        "ar"
+      ],
+      [
+        "p",
+        "et"
+      ],
+      [
+        "p",
+        "al"
+      ],
+      [
+        "p",
+        "ri"
+      ],
+      [
+        "p",
+        "se"
+      ],
+      [
+        "p",
+        "op"
+      ],
+      [
+        "p",
+        "os"
+      ],
+      [
+        "p",
+        "ain"
+      ],
+      [
+        "p",
+        "ort"
+      ],
+      [
+        "p",
+        "ress"
+      ],
+      [
+        "p",
+        "read"
+      ],
+      [
+        "p",
+        "ug"
+      ],
+      [
+        "p",
+        "hic"
+      ],
+      [
+        "r",
+        "u"
+      ],
+      [
+        "r",
+        "it"
+      ],
+      [
+        "r",
+        "ch"
+      ],
+      [
+        "r",
+        "ant"
+      ],
+      [
+        "r",
+        "ag"
+      ],
+      [
+        "r",
+        "ass"
+      ],
+      [
+        "r",
+        "ong"
+      ],
+      [
+        "r",
+        "ation"
+      ],
+      [
+        "r",
+        "ance"
+      ],
+      [
+        "r",
+        "up"
+      ],
+      [
+        "r",
+        "nie"
+      ],
+      [
+        "r",
+        "ving"
+      ],
+      [
+        "s",
+        "w"
+      ],
+      [
+        "s",
+        "y"
+      ],
+      [
+        "s",
+        "ed"
+      ],
+      [
+        "s",
+        "ing"
+      ],
+      [
+        "s",
+        "ell"
+      ],
+      [
+        "s",
+        "am"
+      ],
+      [
+        "s",
+        "ent"
+      ],
+      [
+        "s",
+        "ion"
+      ],
+      [
+        "s",
+        "pe"
+      ],
+      [
+        "s",
+        "per"
+      ],
+      [
+        "s",
+        "ible"
+      ],
+      [
+        "s",
+        "ign"
+      ],
+      [
+        "s",
+        "hit"
+      ],
+      [
+        "s",
+        "pread"
+      ],
+      [
+        "t",
+        "u"
+      ],
+      [
+        "t",
+        "w"
+      ],
+      [
+        "t",
+        "he"
+      ],
+      [
+        "t",
+        "in"
+      ],
+      [
+        "t",
+        "on"
+      ],
+      [
+        "t",
+        "ed"
+      ],
+      [
+        "t",
+        "le"
+      ],
+      [
+        "t",
+        "op"
+      ],
+      [
+        "t",
+        "ra"
+      ],
+      [
+        "t",
+        "ic"
+      ],
+      [
+        "u",
+        "u"
+      ],
+      [
+        "u",
+        "is"
+      ],
+      [
+        "u",
+        "es"
+      ],
+      [
+        "u",
+        "ed"
+      ],
+      [
+        "u",
+        "ro"
+      ],
+      [
+        "u",
+        "ct"
+      ],
+      [
+        "u",
+        "ate"
+      ],
+      [
+        "u",
+        "ndo"
+      ],
+      [
+        "u",
+        "hng"
+      ],
+      [
+        "v",
+        "a"
+      ],
+      [
+        "v",
+        "y"
+      ],
+      [
+        "v",
+        "al"
+      ],
+      [
+        "w",
+        "ar"
+      ],
+      [
+        "w",
+        "ing"
+      ],
+      [
+        "w",
+        "ell"
+      ],
+      [
+        "w",
+        "are"
+      ],
+      [
+        "w",
+        "ord"
+      ],
+      [
+        "y",
+        "p"
+      ],
+      [
+        "y",
+        "er"
+      ],
+      [
+        "y",
+        "ster"
+      ],
+      [
+        "y",
+        "ze"
+      ],
+      [
+        "y",
+        "ard"
+      ],
+      [
+        "y",
+        "bean"
+      ],
+      [
+        "Ġ",
+        "5"
+      ],
+      [
+        "Ġ",
+        "ice"
+      ],
+      [
+        "Ġ",
+        "ought"
+      ],
+      [
+        "Ġ",
+        "round"
+      ],
+      [
+        "Ġ",
+        "oun"
+      ],
+      [
+        "Ġ",
+        "700"
+      ],
+      [
+        "Ġt",
+        "a"
+      ],
+      [
+        "Ġt",
+        "all"
+      ],
+      [
+        "Ġt",
+        "ack"
+      ],
+      [
+        "Ġt",
+        "ee"
+      ],
+      [
+        "Ġt",
+        "est"
+      ],
+      [
+        "Ġt",
+        "ain"
+      ],
+      [
+        "Ġt",
+        "akes"
+      ],
+      [
+        "Ġt",
+        "aught"
+      ],
+      [
+        "Ġt",
+        "ip"
+      ],
+      [
+        "Ġt",
+        "ried"
+      ],
+      [
+        "Ġt",
+        "ired"
+      ],
+      [
+        "Ġt",
+        "ail"
+      ],
+      [
+        "Ġt",
+        "ulip"
+      ],
+      [
+        "he",
+        "tic"
+      ],
+      [
+        "ou",
+        "d"
+      ],
+      [
+        "ou",
+        "ge"
+      ],
+      [
+        "ou",
+        "gl"
+      ],
+      [
+        "ou",
+        "fl"
+      ],
+      [
+        "Ġa",
+        "ck"
+      ],
+      [
+        "Ġa",
+        "ir"
+      ],
+      [
+        "Ġa",
+        "ble"
+      ],
+      [
+        "Ġa",
+        "pt"
+      ],
+      [
+        "Ġa",
+        "while"
+      ],
+      [
+        "Ġa",
+        "ware"
+      ],
+      [
+        "in",
+        "a"
+      ],
+      [
+        "in",
+        "es"
+      ],
+      [
+        "in",
+        "ct"
+      ],
+      [
+        "Ġw",
+        "ake"
+      ],
+      [
+        "Ġw",
+        "ol"
+      ],
+      [
+        "Ġw",
+        "ide"
+      ],
+      [
+        "Ġw",
+        "had"
+      ],
+      [
+        "Ġw",
+        "hit"
+      ],
+      [
+        "Ġw",
+        "hite"
+      ],
+      [
+        "Ġw",
+        "ax"
+      ],
+      [
+        "Ġw",
+        "hether"
+      ],
+      [
+        "Ġw",
+        "ild"
+      ],
+      [
+        "ĠI",
+        "ndo"
+      ],
+      [
+        "ĠI",
+        "rving"
+      ],
+      [
+        "Ġs",
+        "hat"
+      ],
+      [
+        "Ġs",
+        "ing"
+      ],
+      [
+        "Ġs",
+        "uck"
+      ],
+      [
+        "Ġs",
+        "ad"
+      ],
+      [
+        "Ġs",
+        "ent"
+      ],
+      [
+        "Ġs",
+        "ight"
+      ],
+      [
+        "Ġs",
+        "ister"
+      ],
+      [
+        "Ġs",
+        "ip"
+      ],
+      [
+        "Ġs",
+        "ince"
+      ],
+      [
+        "Ġs",
+        "itting"
+      ],
+      [
+        "Ġs",
+        "weet"
+      ],
+      [
+        "Ġs",
+        "nout"
+      ],
+      [
+        "re",
+        "nd"
+      ],
+      [
+        "re",
+        "al"
+      ],
+      [
+        "re",
+        "st"
+      ],
+      [
+        "re",
+        "act"
+      ],
+      [
+        "re",
+        "ady"
+      ],
+      [
+        "re",
+        "gar"
+      ],
+      [
+        "on",
+        "es"
+      ],
+      [
+        "on",
+        "ed"
+      ],
+      [
+        "on",
+        "se"
+      ],
+      [
+        "on",
+        "un"
+      ],
+      [
+        "on",
+        "th"
+      ],
+      [
+        "on",
+        "iz"
+      ],
+      [
+        "ha",
+        "ll"
+      ],
+      [
+        "ha",
+        "rd"
+      ],
+      [
+        "Ġy",
+        "ak"
+      ],
+      [
+        "Ġb",
+        "or"
+      ],
+      [
+        "Ġb",
+        "ow"
+      ],
+      [
+        "Ġb",
+        "at"
+      ],
+      [
+        "Ġb",
+        "uck"
+      ],
+      [
+        "Ġb",
+        "ri"
+      ],
+      [
+        "Ġb",
+        "ust"
+      ],
+      [
+        "Ġb",
+        "od"
+      ],
+      [
+        "Ġb",
+        "other"
+      ],
+      [
+        "Ġb",
+        "our"
+      ],
+      [
+        "Ġb",
+        "ark"
+      ],
+      [
+        "Ġb",
+        "old"
+      ],
+      [
+        "Ġb",
+        "ins"
+      ],
+      [
+        "Ġb",
+        "reat"
+      ],
+      [
+        "Ġb",
+        "ones"
+      ],
+      [
+        "Ġm",
+        "er"
+      ],
+      [
+        "Ġm",
+        "or"
+      ],
+      [
+        "Ġm",
+        "ar"
+      ],
+      [
+        "Ġm",
+        "id"
+      ],
+      [
+        "Ġm",
+        "am"
+      ],
+      [
+        "Ġm",
+        "ak"
+      ],
+      [
+        "Ġm",
+        "other"
+      ],
+      [
+        "Ġm",
+        "ight"
+      ],
+      [
+        "Ġm",
+        "use"
+      ],
+      [
+        "Ġm",
+        "ain"
+      ],
+      [
+        "Ġm",
+        "ap"
+      ],
+      [
+        "Ġm",
+        "ush"
+      ],
+      [
+        "Ġm",
+        "ilk"
+      ],
+      [
+        "Ġm",
+        "onth"
+      ],
+      [
+        "Ġyou",
+        "ng"
+      ],
+      [
+        "Ġthe",
+        "at"
+      ],
+      [
+        "Ġthe",
+        "olo"
+      ],
+      [
+        "Ġd",
+        "et"
+      ],
+      [
+        "Ġd",
+        "uck"
+      ],
+      [
+        "Ġd",
+        "om"
+      ],
+      [
+        "Ġd",
+        "ut"
+      ],
+      [
+        "Ġd",
+        "ro"
+      ],
+      [
+        "Ġd",
+        "em"
+      ],
+      [
+        "Ġd",
+        "ea"
+      ],
+      [
+        "Ġd",
+        "ra"
+      ],
+      [
+        "Ġd",
+        "ies"
+      ],
+      [
+        "Ġd",
+        "ue"
+      ],
+      [
+        "Ġd",
+        "ren"
+      ],
+      [
+        "Ġd",
+        "aught"
+      ],
+      [
+        "Ġd",
+        "ork"
+      ],
+      [
+        "Ġd",
+        "orks"
+      ],
+      [
+        "Ġd",
+        "umb"
+      ],
+      [
+        "Ġd",
+        "ressed"
+      ],
+      [
+        "Ġg",
+        "or"
+      ],
+      [
+        "Ġg",
+        "im"
+      ],
+      [
+        "Ġg",
+        "ig"
+      ],
+      [
+        "Ġg",
+        "ame"
+      ],
+      [
+        "Ġg",
+        "round"
+      ],
+      [
+        "Ġg",
+        "lo"
+      ],
+      [
+        "Ġg",
+        "ittin"
+      ],
+      [
+        "Ġg",
+        "yp"
+      ],
+      [
+        "Ġf",
+        "u"
+      ],
+      [
+        "Ġf",
+        "it"
+      ],
+      [
+        "Ġf",
+        "er"
+      ],
+      [
+        "Ġf",
+        "ri"
+      ],
+      [
+        "Ġf",
+        "ill"
+      ],
+      [
+        "Ġf",
+        "em"
+      ],
+      [
+        "Ġf",
+        "ir"
+      ],
+      [
+        "Ġf",
+        "right"
+      ],
+      [
+        "Ġf",
+        "ac"
+      ],
+      [
+        "Ġf",
+        "ren"
+      ],
+      [
+        "Ġf",
+        "are"
+      ],
+      [
+        "Ġf",
+        "ree"
+      ],
+      [
+        "Ġf",
+        "ought"
+      ],
+      [
+        "Ġf",
+        "oll"
+      ],
+      [
+        "Ġf",
+        "les"
+      ],
+      [
+        "Ġf",
+        "ried"
+      ],
+      [
+        "Ġf",
+        "unn"
+      ],
+      [
+        "Ġf",
+        "ired"
+      ],
+      [
+        "Ġf",
+        "aster"
+      ],
+      [
+        "Ġf",
+        "urn"
+      ],
+      [
+        "Ġf",
+        "rench"
+      ],
+      [
+        "er",
+        "st"
+      ],
+      [
+        "er",
+        "ations"
+      ],
+      [
+        "er",
+        "cise"
+      ],
+      [
+        "er",
+        "oin"
+      ],
+      [
+        "an",
+        "ge"
+      ],
+      [
+        "an",
+        "illa"
+      ],
+      [
+        "is",
+        "p"
+      ],
+      [
+        "is",
+        "ed"
+      ],
+      [
+        "is",
+        "hed"
+      ],
+      [
+        "Ġc",
+        "et"
+      ],
+      [
+        "Ġc",
+        "ut"
+      ],
+      [
+        "Ġc",
+        "al"
+      ],
+      [
+        "Ġc",
+        "am"
+      ],
+      [
+        "Ġc",
+        "ook"
+      ],
+      [
+        "Ġc",
+        "ig"
+      ],
+      [
+        "Ġc",
+        "our"
+      ],
+      [
+        "Ġc",
+        "ol"
+      ],
+      [
+        "Ġc",
+        "red"
+      ],
+      [
+        "Ġc",
+        "av"
+      ],
+      [
+        "Ġc",
+        "row"
+      ],
+      [
+        "Ġc",
+        "urt"
+      ],
+      [
+        "Ġc",
+        "ustomers"
+      ],
+      [
+        "Ġc",
+        "aus"
+      ],
+      [
+        "nd",
+        "y"
+      ],
+      [
+        "nd",
+        "in"
+      ],
+      [
+        "nd",
+        "erest"
+      ],
+      [
+        "Ġo",
+        "h"
+      ],
+      [
+        "Ġo",
+        "cc"
+      ],
+      [
+        "Ġo",
+        "af"
+      ],
+      [
+        "Ġo",
+        "mel"
+      ],
+      [
+        "Ġto",
+        "ast"
+      ],
+      [
+        "Ġto",
+        "day"
+      ],
+      [
+        "Ġto",
+        "bac"
+      ],
+      [
+        "Ġto",
+        "rch"
+      ],
+      [
+        "ot",
+        "sa"
+      ],
+      [
+        "ot",
+        "ogra"
+      ],
+      [
+        "Ġl",
+        "ed"
+      ],
+      [
+        "Ġl",
+        "at"
+      ],
+      [
+        "Ġl",
+        "am"
+      ],
+      [
+        "Ġl",
+        "em"
+      ],
+      [
+        "Ġl",
+        "ag"
+      ],
+      [
+        "Ġl",
+        "os"
+      ],
+      [
+        "Ġl",
+        "one"
+      ],
+      [
+        "Ġl",
+        "ac"
+      ],
+      [
+        "Ġl",
+        "ine"
+      ],
+      [
+        "Ġl",
+        "end"
+      ],
+      [
+        "Ġl",
+        "ue"
+      ],
+      [
+        "Ġl",
+        "aw"
+      ],
+      [
+        "Ġl",
+        "adies"
+      ],
+      [
+        "Ġl",
+        "ift"
+      ],
+      [
+        "ĠW",
+        "on"
+      ],
+      [
+        "ĠW",
+        "as"
+      ],
+      [
+        "ĠW",
+        "ay"
+      ],
+      [
+        "ĠW",
+        "ind"
+      ],
+      [
+        "ĠW",
+        "alk"
+      ],
+      [
+        "ĠW",
+        "ait"
+      ],
+      [
+        "ĠW",
+        "ipe"
+      ],
+      [
+        "ĠW",
+        "hether"
+      ],
+      [
+        "ĠW",
+        "rong"
+      ],
+      [
+        "Ġn",
+        "at"
+      ],
+      [
+        "Ġn",
+        "im"
+      ],
+      [
+        "Ġn",
+        "one"
+      ],
+      [
+        "Ġn",
+        "ine"
+      ],
+      [
+        "Ġn",
+        "urs"
+      ],
+      [
+        "Ġn",
+        "uis"
+      ],
+      [
+        "ck",
+        "oned"
+      ],
+      [
+        "Ġit",
+        "ty"
+      ],
+      [
+        "or",
+        "y"
+      ],
+      [
+        "or",
+        "an"
+      ],
+      [
+        "or",
+        "id"
+      ],
+      [
+        "or",
+        "th"
+      ],
+      [
+        "or",
+        "ious"
+      ],
+      [
+        "or",
+        "table"
+      ],
+      [
+        "ow",
+        "der"
+      ],
+      [
+        "Ġp",
+        "it"
+      ],
+      [
+        "Ġp",
+        "et"
+      ],
+      [
+        "Ġp",
+        "ad"
+      ],
+      [
+        "Ġp",
+        "rou"
+      ],
+      [
+        "Ġp",
+        "ul"
+      ],
+      [
+        "Ġp",
+        "ee"
+      ],
+      [
+        "Ġp",
+        "ool"
+      ],
+      [
+        "Ġp",
+        "ain"
+      ],
+      [
+        "Ġp",
+        "ap"
+      ],
+      [
+        "Ġp",
+        "ist"
+      ],
+      [
+        "Ġp",
+        "ants"
+      ],
+      [
+        "Ġp",
+        "ec"
+      ],
+      [
+        "Ġp",
+        "uff"
+      ],
+      [
+        "Ġp",
+        "ork"
+      ],
+      [
+        "Ġp",
+        "ush"
+      ],
+      [
+        "Ġp",
+        "ipe"
+      ],
+      [
+        "Ġp",
+        "hase"
+      ],
+      [
+        "Ġp",
+        "itch"
+      ],
+      [
+        "Ġp",
+        "atio"
+      ],
+      [
+        "Ġp",
+        "ooh"
+      ],
+      [
+        "Ġp",
+        "umpkin"
+      ],
+      [
+        "Ġp",
+        "ortable"
+      ],
+      [
+        "Ġp",
+        "owder"
+      ],
+      [
+        "ar",
+        "ue"
+      ],
+      [
+        "ar",
+        "ib"
+      ],
+      [
+        "et",
+        "e"
+      ],
+      [
+        "et",
+        "or"
+      ],
+      [
+        "et",
+        "ch"
+      ],
+      [
+        "et",
+        "ter"
+      ],
+      [
+        "et",
+        "te"
+      ],
+      [
+        "Ġth",
+        "in"
+      ],
+      [
+        "Ġth",
+        "ro"
+      ],
+      [
+        "Ġth",
+        "ick"
+      ],
+      [
+        "Ġth",
+        "irty"
+      ],
+      [
+        "Ġth",
+        "reat"
+      ],
+      [
+        "Ġhe",
+        "aven"
+      ],
+      [
+        "en",
+        "s"
+      ],
+      [
+        "en",
+        "in"
+      ],
+      [
+        "en",
+        "ing"
+      ],
+      [
+        "en",
+        "ver"
+      ],
+      [
+        "en",
+        "ge"
+      ],
+      [
+        "en",
+        "ces"
+      ],
+      [
+        "en",
+        "hous"
+      ],
+      [
+        "as",
+        "y"
+      ],
+      [
+        "as",
+        "ped"
+      ],
+      [
+        "as",
+        "phe"
+      ],
+      [
+        "Ġin",
+        "cident"
+      ],
+      [
+        "Ġin",
+        "sign"
+      ],
+      [
+        "ed",
+        "ay"
+      ],
+      [
+        "ed",
+        "ie"
+      ],
+      [
+        "ĠT",
+        "ho"
+      ],
+      [
+        "ĠT",
+        "ime"
+      ],
+      [
+        "ĠT",
+        "old"
+      ],
+      [
+        "ĠT",
+        "oss"
+      ],
+      [
+        "ĠT",
+        "onight"
+      ],
+      [
+        "ĠT",
+        "aster"
+      ],
+      [
+        "ĠT",
+        "HE"
+      ],
+      [
+        "ĠT",
+        "ahit"
+      ],
+      [
+        "ĠT",
+        "ues"
+      ],
+      [
+        "ing",
+        "s"
+      ],
+      [
+        "ing",
+        "ful"
+      ],
+      [
+        "ing",
+        "ling"
+      ],
+      [
+        "us",
+        "ive"
+      ],
+      [
+        "us",
+        "ic"
+      ],
+      [
+        "us",
+        "boy"
+      ],
+      [
+        "us",
+        "sell"
+      ],
+      [
+        "le",
+        "ar"
+      ],
+      [
+        "le",
+        "ven"
+      ],
+      [
+        "le",
+        "head"
+      ],
+      [
+        "ve",
+        "lop"
+      ],
+      [
+        "ve",
+        "yard"
+      ],
+      [
+        "at",
+        "es"
+      ],
+      [
+        "at",
+        "ive"
+      ],
+      [
+        "at",
+        "so"
+      ],
+      [
+        "at",
+        "isfied"
+      ],
+      [
+        "at",
+        "ement"
+      ],
+      [
+        "at",
+        "hetic"
+      ],
+      [
+        "Ġbe",
+        "ver"
+      ],
+      [
+        "Ġbe",
+        "autiful"
+      ],
+      [
+        "uck",
+        "lehead"
+      ],
+      [
+        "oo",
+        "p"
+      ],
+      [
+        "oo",
+        "ooh"
+      ],
+      [
+        "Ġh",
+        "ot"
+      ],
+      [
+        "Ġh",
+        "om"
+      ],
+      [
+        "Ġh",
+        "op"
+      ],
+      [
+        "Ġh",
+        "ide"
+      ],
+      [
+        "Ġh",
+        "um"
+      ],
+      [
+        "Ġh",
+        "ittin"
+      ],
+      [
+        "Ġh",
+        "ip"
+      ],
+      [
+        "Ġh",
+        "ope"
+      ],
+      [
+        "Ġh",
+        "ors"
+      ],
+      [
+        "Ġh",
+        "ogs"
+      ],
+      [
+        "Ġh",
+        "yster"
+      ],
+      [
+        "ĠY",
+        "ummy"
+      ],
+      [
+        "Ġon",
+        "es"
+      ],
+      [
+        "om",
+        "in"
+      ],
+      [
+        "om",
+        "bies"
+      ],
+      [
+        "ay",
+        "ne"
+      ],
+      [
+        "id",
+        "ed"
+      ],
+      [
+        "id",
+        "ence"
+      ],
+      [
+        "Ġme",
+        "lt"
+      ],
+      [
+        "ut",
+        "al"
+      ],
+      [
+        "ut",
+        "ion"
+      ],
+      [
+        "ut",
+        "ta"
+      ],
+      [
+        "ell",
+        "ed"
+      ],
+      [
+        "ell",
+        "ybean"
+      ],
+      [
+        "al",
+        "f"
+      ],
+      [
+        "al",
+        "if"
+      ],
+      [
+        "al",
+        "ry"
+      ],
+      [
+        "al",
+        "ib"
+      ],
+      [
+        "al",
+        "obos"
+      ],
+      [
+        "al",
+        "yze"
+      ],
+      [
+        "Ġe",
+        "nd"
+      ],
+      [
+        "Ġe",
+        "ld"
+      ],
+      [
+        "Ġe",
+        "ars"
+      ],
+      [
+        "Ġe",
+        "ight"
+      ],
+      [
+        "Ġe",
+        "qu"
+      ],
+      [
+        "Ġe",
+        "lem"
+      ],
+      [
+        "Ġe",
+        "go"
+      ],
+      [
+        "Ġe",
+        "ggs"
+      ],
+      [
+        "Ġe",
+        "pis"
+      ],
+      [
+        "ĠM",
+        "ad"
+      ],
+      [
+        "ĠM",
+        "am"
+      ],
+      [
+        "ĠM",
+        "ag"
+      ],
+      [
+        "ĠM",
+        "ake"
+      ],
+      [
+        "ĠM",
+        "ind"
+      ],
+      [
+        "ĠM",
+        "um"
+      ],
+      [
+        "ĠM",
+        "uch"
+      ],
+      [
+        "ĠM",
+        "ans"
+      ],
+      [
+        "ĠM",
+        "oun"
+      ],
+      [
+        "ĠM",
+        "ilk"
+      ],
+      [
+        "ĠM",
+        "ax"
+      ],
+      [
+        "ĠM",
+        "OT"
+      ],
+      [
+        "ĠM",
+        "aj"
+      ],
+      [
+        "ĠM",
+        "cCoy"
+      ],
+      [
+        "ĠM",
+        "edie"
+      ],
+      [
+        "ĠM",
+        "usic"
+      ],
+      [
+        "ĠM",
+        "alib"
+      ],
+      [
+        "Ġsh",
+        "y"
+      ],
+      [
+        "Ġsh",
+        "ut"
+      ],
+      [
+        "Ġsh",
+        "ook"
+      ],
+      [
+        "Ġsh",
+        "oe"
+      ],
+      [
+        "Ġsh",
+        "ift"
+      ],
+      [
+        "Ġsh",
+        "irt"
+      ],
+      [
+        "ld",
+        "om"
+      ],
+      [
+        "ĠA",
+        "M"
+      ],
+      [
+        "ĠA",
+        "ct"
+      ],
+      [
+        "ĠA",
+        "ir"
+      ],
+      [
+        "ĠA",
+        "cc"
+      ],
+      [
+        "ĠA",
+        "side"
+      ],
+      [
+        "ĠA",
+        "sta"
+      ],
+      [
+        "ĠA",
+        "fric"
+      ],
+      [
+        "ĠB",
+        "ell"
+      ],
+      [
+        "ĠB",
+        "ad"
+      ],
+      [
+        "ĠB",
+        "ust"
+      ],
+      [
+        "ĠB",
+        "ars"
+      ],
+      [
+        "ĠB",
+        "ox"
+      ],
+      [
+        "ĠB",
+        "ank"
+      ],
+      [
+        "ĠB",
+        "aby"
+      ],
+      [
+        "ĠB",
+        "ring"
+      ],
+      [
+        "ĠB",
+        "ash"
+      ],
+      [
+        "ĠB",
+        "ava"
+      ],
+      [
+        "ĠB",
+        "oran"
+      ],
+      [
+        "ĠB",
+        "etter"
+      ],
+      [
+        "ĠB",
+        "usboy"
+      ],
+      [
+        "Ġfuck",
+        "s"
+      ],
+      [
+        "Ġfuck",
+        "er"
+      ],
+      [
+        "Ġk",
+        "un"
+      ],
+      [
+        "Ġk",
+        "itty"
+      ],
+      [
+        "Ġk",
+        "ooties"
+      ],
+      [
+        "Ġk",
+        "etch"
+      ],
+      [
+        "ch",
+        "niqu"
+      ],
+      [
+        "ĠYou",
+        "ng"
+      ],
+      [
+        "ad",
+        "in"
+      ],
+      [
+        "am",
+        "s"
+      ],
+      [
+        "am",
+        "ora"
+      ],
+      [
+        "am",
+        "ount"
+      ],
+      [
+        "am",
+        "undo"
+      ],
+      [
+        "ĠH",
+        "a"
+      ],
+      [
+        "ĠH",
+        "is"
+      ],
+      [
+        "ĠH",
+        "im"
+      ],
+      [
+        "ĠH",
+        "op"
+      ],
+      [
+        "ĠH",
+        "ur"
+      ],
+      [
+        "ĠH",
+        "art"
+      ],
+      [
+        "ĠH",
+        "aw"
+      ],
+      [
+        "ĠH",
+        "ard"
+      ],
+      [
+        "ĠH",
+        "ang"
+      ],
+      [
+        "ĠH",
+        "ope"
+      ],
+      [
+        "ĠH",
+        "oly"
+      ],
+      [
+        "ĠH",
+        "uhng"
+      ],
+      [
+        "ĠH",
+        "eroin"
+      ],
+      [
+        "ĠH",
+        "alf"
+      ],
+      [
+        "ri",
+        "l"
+      ],
+      [
+        "ri",
+        "p"
+      ],
+      [
+        "ri",
+        "ve"
+      ],
+      [
+        "ri",
+        "age"
+      ],
+      [
+        "ri",
+        "fied"
+      ],
+      [
+        "ri",
+        "gu"
+      ],
+      [
+        "ĠN",
+        "on"
+      ],
+      [
+        "ĠN",
+        "ig"
+      ],
+      [
+        "ĠN",
+        "one"
+      ],
+      [
+        "ĠN",
+        "orm"
+      ],
+      [
+        "ĠN",
+        "ormal"
+      ],
+      [
+        "ĠN",
+        "ope"
+      ],
+      [
+        "ĠN",
+        "AV"
+      ],
+      [
+        "ĠN",
+        "ext"
+      ],
+      [
+        "ĠN",
+        "orth"
+      ],
+      [
+        "ĠS",
+        "et"
+      ],
+      [
+        "ĠS",
+        "ent"
+      ],
+      [
+        "ĠS",
+        "ir"
+      ],
+      [
+        "ĠS",
+        "ho"
+      ],
+      [
+        "ĠS",
+        "ome"
+      ],
+      [
+        "ĠS",
+        "ac"
+      ],
+      [
+        "ĠS",
+        "omet"
+      ],
+      [
+        "ĠS",
+        "ue"
+      ],
+      [
+        "ĠS",
+        "ound"
+      ],
+      [
+        "ĠS",
+        "li"
+      ],
+      [
+        "ĠS",
+        "leep"
+      ],
+      [
+        "ĠS",
+        "outh"
+      ],
+      [
+        "ĠS",
+        "aus"
+      ],
+      [
+        "ĠS",
+        "ince"
+      ],
+      [
+        "ĠS",
+        "amoan"
+      ],
+      [
+        "ĠS",
+        "weet"
+      ],
+      [
+        "ĠS",
+        "PY"
+      ],
+      [
+        "ĠS",
+        "cot"
+      ],
+      [
+        "ĠS",
+        "atisfied"
+      ],
+      [
+        "Ġwe",
+        "ight"
+      ],
+      [
+        "Ġwas",
+        "hed"
+      ],
+      [
+        "im",
+        "ent"
+      ],
+      [
+        "im",
+        "atin"
+      ],
+      [
+        "im",
+        "ens"
+      ],
+      [
+        "Ġwhat",
+        "ever"
+      ],
+      [
+        "Ġst",
+        "ing"
+      ],
+      [
+        "Ġst",
+        "uck"
+      ],
+      [
+        "Ġst",
+        "all"
+      ],
+      [
+        "Ġst",
+        "and"
+      ],
+      [
+        "Ġst",
+        "ren"
+      ],
+      [
+        "Ġst",
+        "eal"
+      ],
+      [
+        "Ġst",
+        "ations"
+      ],
+      [
+        "Ġst",
+        "amps"
+      ],
+      [
+        "Ġst",
+        "rag"
+      ],
+      [
+        "Ġst",
+        "atement"
+      ],
+      [
+        "ĠWhat",
+        "a"
+      ],
+      [
+        "ĠWhat",
+        "ever"
+      ],
+      [
+        "ĠWhat",
+        "sam"
+      ],
+      [
+        "Ġan",
+        "gry"
+      ],
+      [
+        "Ġan",
+        "sw"
+      ],
+      [
+        "ill",
+        "s"
+      ],
+      [
+        "ill",
+        "ing"
+      ],
+      [
+        "ill",
+        "alobos"
+      ],
+      [
+        "Ġu",
+        "h"
+      ],
+      [
+        "Ġu",
+        "ntil"
+      ],
+      [
+        "Ġu",
+        "nderest"
+      ],
+      [
+        "ent",
+        "s"
+      ],
+      [
+        "ent",
+        "ly"
+      ],
+      [
+        "ĠD",
+        "ad"
+      ],
+      [
+        "ĠD",
+        "ie"
+      ],
+      [
+        "ĠD",
+        "ore"
+      ],
+      [
+        "ĠD",
+        "od"
+      ],
+      [
+        "ĠD",
+        "ur"
+      ],
+      [
+        "ĠD",
+        "own"
+      ],
+      [
+        "ĠD",
+        "ough"
+      ],
+      [
+        "ĠD",
+        "orks"
+      ],
+      [
+        "ĠD",
+        "ougl"
+      ],
+      [
+        "ĠD",
+        "enver"
+      ],
+      [
+        "Ġgo",
+        "dammit"
+      ],
+      [
+        "Ġli",
+        "p"
+      ],
+      [
+        "ĠThe",
+        "m"
+      ],
+      [
+        "Ġj",
+        "ack"
+      ],
+      [
+        "Ġj",
+        "oy"
+      ],
+      [
+        "Ġj",
+        "ang"
+      ],
+      [
+        "Ġj",
+        "ail"
+      ],
+      [
+        "Ġj",
+        "ingling"
+      ],
+      [
+        "Ġj",
+        "ellybean"
+      ],
+      [
+        "st",
+        "ore"
+      ],
+      [
+        "st",
+        "ory"
+      ],
+      [
+        "st",
+        "ril"
+      ],
+      [
+        "Ġre",
+        "qu"
+      ],
+      [
+        "Ġre",
+        "ach"
+      ],
+      [
+        "Ġre",
+        "pug"
+      ],
+      [
+        "Ġre",
+        "ckoned"
+      ],
+      [
+        "Ġgot",
+        "s"
+      ],
+      [
+        "Ġfor",
+        "ce"
+      ],
+      [
+        "Ġfor",
+        "ced"
+      ],
+      [
+        "ro",
+        "d"
+      ],
+      [
+        "ĠJ",
+        "ody"
+      ],
+      [
+        "ĠJ",
+        "ohn"
+      ],
+      [
+        "ĠJ",
+        "ayne"
+      ],
+      [
+        "Ġknow",
+        "n"
+      ],
+      [
+        "Ġout",
+        "side"
+      ],
+      [
+        "Ġout",
+        "fit"
+      ],
+      [
+        "Ġne",
+        "xt"
+      ],
+      [
+        "se",
+        "as"
+      ],
+      [
+        "se",
+        "lor"
+      ],
+      [
+        "Ġman",
+        "iac"
+      ],
+      [
+        "...",
+        "!"
+      ],
+      [
+        "...",
+        "\""
+      ],
+      [
+        "...",
+        "?"
+      ],
+      [
+        "ct",
+        "ion"
+      ],
+      [
+        "ant",
+        "e"
+      ],
+      [
+        "ir",
+        "ing"
+      ],
+      [
+        "ir",
+        "by"
+      ],
+      [
+        "ho",
+        "d"
+      ],
+      [
+        "ĠC",
+        "all"
+      ],
+      [
+        "ĠC",
+        "op"
+      ],
+      [
+        "ĠC",
+        "ol"
+      ],
+      [
+        "ĠC",
+        "ap"
+      ],
+      [
+        "ĠC",
+        "ary"
+      ],
+      [
+        "ĠC",
+        "lim"
+      ],
+      [
+        "ĠC",
+        "oun"
+      ],
+      [
+        "ĠC",
+        "aine"
+      ],
+      [
+        "ĠC",
+        "hall"
+      ],
+      [
+        "ĠC",
+        "arib"
+      ],
+      [
+        "ĠC",
+        "lear"
+      ],
+      [
+        "ĠC",
+        "omin"
+      ],
+      [
+        "ood",
+        "ed"
+      ],
+      [
+        "ĠG",
+        "ra"
+      ],
+      [
+        "ĠG",
+        "rand"
+      ],
+      [
+        "ĠG",
+        "entlemen"
+      ],
+      [
+        "ĠG",
+        "reat"
+      ],
+      [
+        "ĠG",
+        "iven"
+      ],
+      [
+        "ĠG",
+        "iving"
+      ],
+      [
+        "ĠG",
+        "rant"
+      ],
+      [
+        "ag",
+        "s"
+      ],
+      [
+        "ag",
+        "ue"
+      ],
+      [
+        "ag",
+        "ull"
+      ],
+      [
+        "ĠF",
+        "U"
+      ],
+      [
+        "ĠF",
+        "il"
+      ],
+      [
+        "ĠF",
+        "ore"
+      ],
+      [
+        "ĠF",
+        "ight"
+      ],
+      [
+        "ĠF",
+        "oot"
+      ],
+      [
+        "ĠF",
+        "ine"
+      ],
+      [
+        "ĠF",
+        "riend"
+      ],
+      [
+        "ĠF",
+        "ox"
+      ],
+      [
+        "ĠF",
+        "eel"
+      ],
+      [
+        "ĠF",
+        "unny"
+      ],
+      [
+        "ĠF",
+        "ederal"
+      ],
+      [
+        "ĠF",
+        "IV"
+      ],
+      [
+        "ĠF",
+        "OR"
+      ],
+      [
+        "ĠF",
+        "air"
+      ],
+      [
+        "ĠF",
+        "eather"
+      ],
+      [
+        "ĠF",
+        "rance"
+      ],
+      [
+        "ĠF",
+        "atso"
+      ],
+      [
+        "ook",
+        "a"
+      ],
+      [
+        "ĠO",
+        "F"
+      ],
+      [
+        "ĠO",
+        "f"
+      ],
+      [
+        "ĠO",
+        "r"
+      ],
+      [
+        "ĠO",
+        "ak"
+      ],
+      [
+        "ĠO",
+        "utta"
+      ],
+      [
+        "Ġno",
+        "ise"
+      ],
+      [
+        "Ġno",
+        "stril"
+      ],
+      [
+        "il",
+        "in"
+      ],
+      [
+        "il",
+        "os"
+      ],
+      [
+        "il",
+        "ities"
+      ],
+      [
+        "il",
+        "iar"
+      ],
+      [
+        "il",
+        "ante"
+      ],
+      [
+        "op",
+        "hy"
+      ],
+      [
+        "un",
+        "k"
+      ],
+      [
+        "un",
+        "ger"
+      ],
+      [
+        "un",
+        "ken"
+      ],
+      [
+        "un",
+        "ette"
+      ],
+      [
+        "ig",
+        "s"
+      ],
+      [
+        "ig",
+        "y"
+      ],
+      [
+        "ig",
+        "ilante"
+      ],
+      [
+        "ak",
+        "s"
+      ],
+      [
+        "ack",
+        "ed"
+      ],
+      [
+        "ter",
+        "fu"
+      ],
+      [
+        "Ġse",
+        "at"
+      ],
+      [
+        "Ġse",
+        "ven"
+      ],
+      [
+        "Ġse",
+        "vent"
+      ],
+      [
+        "Ġse",
+        "wer"
+      ],
+      [
+        "Ġse",
+        "ated"
+      ],
+      [
+        "Ġse",
+        "arch"
+      ],
+      [
+        "Ġse",
+        "par"
+      ],
+      [
+        "Ġse",
+        "wing"
+      ],
+      [
+        "Ġse",
+        "ndin"
+      ],
+      [
+        "Ġse",
+        "ldom"
+      ],
+      [
+        "Ġse",
+        "ction"
+      ],
+      [
+        "Ġher",
+        "s"
+      ],
+      [
+        "ore",
+        "ans"
+      ],
+      [
+        "od",
+        "e"
+      ],
+      [
+        "ta",
+        "urants"
+      ],
+      [
+        "ta",
+        "bly"
+      ],
+      [
+        "ess",
+        "ful"
+      ],
+      [
+        "Ġbut",
+        "ton"
+      ],
+      [
+        "Ġcan",
+        "non"
+      ],
+      [
+        "ĠWe",
+        "ndy"
+      ],
+      [
+        "pp",
+        "le"
+      ],
+      [
+        "ĠAnd",
+        "y"
+      ],
+      [
+        "ĠP",
+        "ie"
+      ],
+      [
+        "ĠP",
+        "ack"
+      ],
+      [
+        "ĠP",
+        "itt"
+      ],
+      [
+        "ĠP",
+        "os"
+      ],
+      [
+        "ĠP",
+        "ick"
+      ],
+      [
+        "ĠP",
+        "ac"
+      ],
+      [
+        "ĠP",
+        "eople"
+      ],
+      [
+        "ĠP",
+        "hone"
+      ],
+      [
+        "ĠP",
+        "anda"
+      ],
+      [
+        "ĠP",
+        "eg"
+      ],
+      [
+        "ĠP",
+        "aul"
+      ],
+      [
+        "ĠP",
+        "ork"
+      ],
+      [
+        "ĠP",
+        "ush"
+      ],
+      [
+        "ĠP",
+        "hase"
+      ],
+      [
+        "ĠP",
+        "ors"
+      ],
+      [
+        "ĠP",
+        "umpkin"
+      ],
+      [
+        "ĠP",
+        "ICT"
+      ],
+      [
+        "ĠP",
+        "oor"
+      ],
+      [
+        "ĠP",
+        "igs"
+      ],
+      [
+        "ight",
+        "en"
+      ],
+      [
+        "ur",
+        "al"
+      ],
+      [
+        "ur",
+        "ant"
+      ],
+      [
+        "ur",
+        "ren"
+      ],
+      [
+        "ĠL",
+        "os"
+      ],
+      [
+        "ĠL",
+        "aw"
+      ],
+      [
+        "ĠL",
+        "isten"
+      ],
+      [
+        "ĠL",
+        "ash"
+      ],
+      [
+        "ĠL",
+        "adies"
+      ],
+      [
+        "ĠL",
+        "ava"
+      ],
+      [
+        "ĠL",
+        "otsa"
+      ],
+      [
+        "ĠL",
+        "arue"
+      ],
+      [
+        "ĠL",
+        "ighten"
+      ],
+      [
+        "ĠNo",
+        "va"
+      ],
+      [
+        "ul",
+        "es"
+      ],
+      [
+        "ul",
+        "iar"
+      ],
+      [
+        "ĠR",
+        "ic"
+      ],
+      [
+        "ĠR",
+        "ain"
+      ],
+      [
+        "ĠR",
+        "ap"
+      ],
+      [
+        "ĠR",
+        "oll"
+      ],
+      [
+        "ĠR",
+        "ouge"
+      ],
+      [
+        "ĠR",
+        "ussell"
+      ],
+      [
+        "Ġde",
+        "vil"
+      ],
+      [
+        "Ġde",
+        "lic"
+      ],
+      [
+        "Ġde",
+        "velop"
+      ],
+      [
+        "ĠV",
+        "an"
+      ],
+      [
+        "ĠV",
+        "ery"
+      ],
+      [
+        "ĠV",
+        "illalobos"
+      ],
+      [
+        "Ġhis",
+        "sy"
+      ],
+      [
+        "Ġass",
+        "oci"
+      ],
+      [
+        "th",
+        "is"
+      ],
+      [
+        "th",
+        "ree"
+      ],
+      [
+        "th",
+        "irty"
+      ],
+      [
+        "Ġor",
+        "ders"
+      ],
+      [
+        "Ġor",
+        "ange"
+      ],
+      [
+        "Ġthink",
+        "ing"
+      ],
+      [
+        "Ġso",
+        "ir"
+      ],
+      [
+        "Ġso",
+        "ak"
+      ],
+      [
+        "Ġso",
+        "lve"
+      ],
+      [
+        "Ġsay",
+        "ing"
+      ],
+      [
+        "os",
+        "et"
+      ],
+      [
+        "Ġ\"",
+        "..."
+      ],
+      [
+        "ic",
+        "ally"
+      ],
+      [
+        "ic",
+        "ated"
+      ],
+      [
+        "Ġmean",
+        "while"
+      ],
+      [
+        "Ġmean",
+        "ingful"
+      ],
+      [
+        "ĠHe",
+        "ar"
+      ],
+      [
+        "Ġwho",
+        "se"
+      ],
+      [
+        "Ġwor",
+        "se"
+      ],
+      [
+        "Ġtalk",
+        "s"
+      ],
+      [
+        "Ġtalk",
+        "ing"
+      ],
+      [
+        "Ġpl",
+        "ain"
+      ],
+      [
+        "Ġpl",
+        "enty"
+      ],
+      [
+        "Ġpl",
+        "ug"
+      ],
+      [
+        "Ġpl",
+        "iers"
+      ],
+      [
+        "Ġpl",
+        "unger"
+      ],
+      [
+        "oy",
+        "ees"
+      ],
+      [
+        "Ġtell",
+        "er"
+      ],
+      [
+        "Ġtell",
+        "ing"
+      ],
+      [
+        "Ġsu",
+        "cc"
+      ],
+      [
+        "Ġsu",
+        "per"
+      ],
+      [
+        "Ġsu",
+        "ggest"
+      ],
+      [
+        "ee",
+        "ch"
+      ],
+      [
+        "ol",
+        "ition"
+      ],
+      [
+        "Ġbl",
+        "ind"
+      ],
+      [
+        "Ġbl",
+        "own"
+      ],
+      [
+        "Ġbl",
+        "ond"
+      ],
+      [
+        "Ġbl",
+        "asphe"
+      ],
+      [
+        "Ġcar",
+        "d"
+      ],
+      [
+        "Ġcar",
+        "ried"
+      ],
+      [
+        "Ġcar",
+        "pet"
+      ],
+      [
+        "est",
+        "icated"
+      ],
+      [
+        "Ġex",
+        "cess"
+      ],
+      [
+        "Ġex",
+        "cuse"
+      ],
+      [
+        "Ġex",
+        "cit"
+      ],
+      [
+        "Ġex",
+        "tra"
+      ],
+      [
+        "Ġex",
+        "ercise"
+      ],
+      [
+        "ĠTh",
+        "ing"
+      ],
+      [
+        "ĠTh",
+        "ink"
+      ],
+      [
+        "ĠTh",
+        "ought"
+      ],
+      [
+        "ĠTh",
+        "urs"
+      ],
+      [
+        "Ġoff",
+        "ice"
+      ],
+      [
+        "ĠE",
+        "ight"
+      ],
+      [
+        "ĠE",
+        "atin"
+      ],
+      [
+        "ĠE",
+        "nough"
+      ],
+      [
+        "ĠE",
+        "rnie"
+      ],
+      [
+        "ĠE",
+        "uro"
+      ],
+      [
+        "ĠE",
+        "leven"
+      ],
+      [
+        "Ġus",
+        "ually"
+      ],
+      [
+        "Ġhow",
+        "ever"
+      ],
+      [
+        "Ġneed",
+        "ed"
+      ],
+      [
+        "ac",
+        "ate"
+      ],
+      [
+        "cent",
+        "ration"
+      ],
+      [
+        "cent",
+        "uate"
+      ],
+      [
+        "Ġsa",
+        "il"
+      ],
+      [
+        "Ġsa",
+        "ved"
+      ],
+      [
+        "Ġsa",
+        "fe"
+      ],
+      [
+        "Ġqu",
+        "it"
+      ],
+      [
+        "Ġqu",
+        "ick"
+      ],
+      [
+        "Ġqu",
+        "iet"
+      ],
+      [
+        "Ġqu",
+        "itting"
+      ],
+      [
+        "Ġqu",
+        "ickly"
+      ],
+      [
+        "Ġqu",
+        "alif"
+      ],
+      [
+        "Ġback",
+        "ground"
+      ],
+      [
+        "ĠJimm",
+        "ied"
+      ],
+      [
+        "Ġbet",
+        "cha"
+      ],
+      [
+        "Ġpro",
+        "gr"
+      ],
+      [
+        "Ġpro",
+        "pri"
+      ],
+      [
+        "Ġpro",
+        "sper"
+      ],
+      [
+        "Ġint",
+        "end"
+      ],
+      [
+        "Ġint",
+        "rigu"
+      ],
+      [
+        "Ġsomet",
+        "ime"
+      ],
+      [
+        "Ġhand",
+        "y"
+      ],
+      [
+        "Ġhand",
+        "ed"
+      ],
+      [
+        "ĠU",
+        "p"
+      ],
+      [
+        "ĠU",
+        "nder"
+      ],
+      [
+        "ĠU",
+        "ntil"
+      ],
+      [
+        "Ġr",
+        "at"
+      ],
+      [
+        "Ġr",
+        "ate"
+      ],
+      [
+        "Ġr",
+        "ation"
+      ],
+      [
+        "Ġr",
+        "ud"
+      ],
+      [
+        "Ġr",
+        "ags"
+      ],
+      [
+        "Ġr",
+        "ules"
+      ],
+      [
+        "Ġover",
+        "react"
+      ],
+      [
+        "Ġover",
+        "seas"
+      ],
+      [
+        "Ġdead",
+        "li"
+      ],
+      [
+        "ge",
+        "les"
+      ],
+      [
+        "Ġro",
+        "ot"
+      ],
+      [
+        "ont",
+        "o"
+      ],
+      [
+        "Ġcom",
+        "pl"
+      ],
+      [
+        "Ġcom",
+        "fortable"
+      ],
+      [
+        "Ġle",
+        "an"
+      ],
+      [
+        "Ġle",
+        "ast"
+      ],
+      [
+        "Ġle",
+        "gs"
+      ],
+      [
+        "Ġle",
+        "ague"
+      ],
+      [
+        "au",
+        "de"
+      ],
+      [
+        "lf",
+        "riend"
+      ],
+      [
+        "Ġbr",
+        "ake"
+      ],
+      [
+        "Ġbr",
+        "ass"
+      ],
+      [
+        "Ġbr",
+        "ide"
+      ],
+      [
+        "Ġbr",
+        "utal"
+      ],
+      [
+        "Ġbr",
+        "unette"
+      ],
+      [
+        "Ġmass",
+        "aged"
+      ],
+      [
+        "Ġday",
+        "light"
+      ],
+      [
+        "Ġco",
+        "ke"
+      ],
+      [
+        "Ġco",
+        "bb"
+      ],
+      [
+        "Ġlo",
+        "ad"
+      ],
+      [
+        "Ġlo",
+        "se"
+      ],
+      [
+        "Ġkill",
+        "s"
+      ],
+      [
+        "Ġkill",
+        "ing"
+      ],
+      [
+        "Ġrem",
+        "ain"
+      ],
+      [
+        "Ġrem",
+        "ark"
+      ],
+      [
+        "act",
+        "ly"
+      ],
+      [
+        "Ġgre",
+        "ase"
+      ],
+      [
+        "Ġgre",
+        "enhous"
+      ],
+      [
+        "Ġgre",
+        "asy"
+      ],
+      [
+        "ci",
+        "as"
+      ],
+      [
+        "ci",
+        "le"
+      ],
+      [
+        "ci",
+        "ation"
+      ],
+      [
+        "ĠK",
+        "ing"
+      ],
+      [
+        "ĠK",
+        "oons"
+      ],
+      [
+        "ĠK",
+        "ooties"
+      ],
+      [
+        "ĠK",
+        "illing"
+      ],
+      [
+        "ĠK",
+        "irby"
+      ],
+      [
+        "ĠK",
+        "oreans"
+      ],
+      [
+        "Ġfight",
+        "s"
+      ],
+      [
+        "Ġfight",
+        "in"
+      ],
+      [
+        "Ġfight",
+        "ing"
+      ],
+      [
+        "Ġcou",
+        "pl"
+      ],
+      [
+        "ĠDo",
+        "ing"
+      ],
+      [
+        "ĠDo",
+        "gs"
+      ],
+      [
+        "Ġbig",
+        "ger"
+      ],
+      [
+        "Ġbig",
+        "gest"
+      ],
+      [
+        "Ġbig",
+        "gie"
+      ],
+      [
+        "Ġdr",
+        "ag"
+      ],
+      [
+        "Ġdr",
+        "own"
+      ],
+      [
+        "Ġdr",
+        "ug"
+      ],
+      [
+        "Ġdr",
+        "unken"
+      ],
+      [
+        "Ġpr",
+        "onun"
+      ],
+      [
+        "Ġpr",
+        "onto"
+      ],
+      [
+        "be",
+        "cile"
+      ],
+      [
+        "Ġag",
+        "ed"
+      ],
+      [
+        "Ġag",
+        "oniz"
+      ],
+      [
+        "Ġag",
+        "ents"
+      ],
+      [
+        "Ġal",
+        "so"
+      ],
+      [
+        "Ġal",
+        "ready"
+      ],
+      [
+        "Ġsp",
+        "an"
+      ],
+      [
+        "Ġsp",
+        "ic"
+      ],
+      [
+        "Ġsp",
+        "ort"
+      ],
+      [
+        "Ġsp",
+        "oons"
+      ],
+      [
+        "Ġsp",
+        "ider"
+      ],
+      [
+        "Ġsp",
+        "urs"
+      ],
+      [
+        "Ġsp",
+        "ring"
+      ],
+      [
+        "Ġsp",
+        "eech"
+      ],
+      [
+        "Ġgun",
+        "ner"
+      ],
+      [
+        "Ġhappen",
+        "ing"
+      ],
+      [
+        "we",
+        "ight"
+      ],
+      [
+        "Ġlot",
+        "ta"
+      ],
+      [
+        "ĠWho",
+        "se"
+      ],
+      [
+        "ĠWho",
+        "pper"
+      ],
+      [
+        "Ġhome",
+        "boy"
+      ],
+      [
+        "ĠShe",
+        "pherd"
+      ],
+      [
+        "ĠLook",
+        "in"
+      ],
+      [
+        "Ġremember",
+        "in"
+      ],
+      [
+        "cc",
+        "ch"
+      ],
+      [
+        "for",
+        "ty"
+      ],
+      [
+        "for",
+        "mers"
+      ],
+      [
+        "Ġv",
+        "oll"
+      ],
+      [
+        "Ġv",
+        "ict"
+      ],
+      [
+        "Ġv",
+        "oice"
+      ],
+      [
+        "Ġv",
+        "anilla"
+      ],
+      [
+        "Ġv",
+        "igilante"
+      ],
+      [
+        "Ġv",
+        "acate"
+      ],
+      [
+        "Ġv",
+        "aude"
+      ],
+      [
+        "Ġtr",
+        "ue"
+      ],
+      [
+        "Ġtr",
+        "adin"
+      ],
+      [
+        "Ġtr",
+        "unk"
+      ],
+      [
+        "Ġwalk",
+        "s"
+      ],
+      [
+        "Ġwalk",
+        "in"
+      ],
+      [
+        "Ġwalk",
+        "ed"
+      ],
+      [
+        "Ġwalk",
+        "ing"
+      ],
+      [
+        "Ġsha",
+        "me"
+      ],
+      [
+        "Ġsha",
+        "kes"
+      ],
+      [
+        "Ġsha",
+        "pes"
+      ],
+      [
+        "res",
+        "pect"
+      ],
+      [
+        "Ġbreak",
+        "s"
+      ],
+      [
+        "Ġmo",
+        "ves"
+      ],
+      [
+        "Ġmo",
+        "ving"
+      ],
+      [
+        "Ġfriend",
+        "s"
+      ],
+      [
+        "Ġgod",
+        "dammit"
+      ],
+      [
+        "Ġboy",
+        "friend"
+      ],
+      [
+        "Ġch",
+        "it"
+      ],
+      [
+        "Ġcha",
+        "mp"
+      ],
+      [
+        "Ġcha",
+        "sing"
+      ],
+      [
+        "Ġcle",
+        "ar"
+      ],
+      [
+        "ĠMar",
+        "y"
+      ],
+      [
+        "ĠMar",
+        "ine"
+      ],
+      [
+        "ĠMar",
+        "ines"
+      ],
+      [
+        "ĠAm",
+        "os"
+      ],
+      [
+        "Ġreal",
+        "istic"
+      ],
+      [
+        "Ġforget",
+        "s"
+      ],
+      [
+        "Ġlove",
+        "ly"
+      ],
+      [
+        "Ġdrink",
+        "s"
+      ],
+      [
+        "Ġagain",
+        "st"
+      ],
+      [
+        "Ġwait",
+        "er"
+      ],
+      [
+        "Ġwait",
+        "ed"
+      ],
+      [
+        "Ġwait",
+        "resses"
+      ],
+      [
+        "Ġsm",
+        "all"
+      ],
+      [
+        "Ġsm",
+        "other"
+      ],
+      [
+        "Ġsm",
+        "elled"
+      ],
+      [
+        "Ġsm",
+        "ilin"
+      ],
+      [
+        "Ġbook",
+        "ed"
+      ],
+      [
+        "Ġbook",
+        "ies"
+      ],
+      [
+        "Ġpie",
+        "ce"
+      ],
+      [
+        "lem",
+        "ma"
+      ],
+      [
+        "Ġstop",
+        "s"
+      ],
+      [
+        "Ġstop",
+        "pin"
+      ],
+      [
+        "ĠChe",
+        "vy"
+      ],
+      [
+        "ĠFor",
+        "ty"
+      ],
+      [
+        "Ġwork",
+        "in"
+      ],
+      [
+        "Ġevery",
+        "one"
+      ],
+      [
+        "Ġevery",
+        "body"
+      ],
+      [
+        "Ġclean",
+        "ing"
+      ],
+      [
+        "Ġclean",
+        "ers"
+      ],
+      [
+        "ye",
+        "ar"
+      ],
+      [
+        "Ġmin",
+        "us"
+      ],
+      [
+        "Ġmet",
+        "al"
+      ],
+      [
+        "Ġmet",
+        "hod"
+      ],
+      [
+        "ĠSt",
+        "ar"
+      ],
+      [
+        "ĠSt",
+        "ay"
+      ],
+      [
+        "ĠSt",
+        "ep"
+      ],
+      [
+        "ĠSt",
+        "udi"
+      ],
+      [
+        "ĠSt",
+        "rip"
+      ],
+      [
+        "Ġun",
+        "real"
+      ],
+      [
+        "Ġkeep",
+        "ing"
+      ],
+      [
+        "Ġdiff",
+        "er"
+      ],
+      [
+        "Ġdiff",
+        "ers"
+      ],
+      [
+        "Ġtast",
+        "es"
+      ],
+      [
+        "Ġapp",
+        "ear"
+      ],
+      [
+        "Ġacc",
+        "ording"
+      ],
+      [
+        "Ġdi",
+        "ed"
+      ],
+      [
+        "Ġdi",
+        "lemma"
+      ],
+      [
+        "Ġfeel",
+        "s"
+      ],
+      [
+        "Ġput",
+        "s"
+      ],
+      [
+        "Ġput",
+        "tin"
+      ],
+      [
+        "Ġpop",
+        "ped"
+      ],
+      [
+        "Ġbel",
+        "ong"
+      ],
+      [
+        "Ġstor",
+        "in"
+      ],
+      [
+        "Ġstor",
+        "ies"
+      ],
+      [
+        "Ġstart",
+        "s"
+      ],
+      [
+        "Ġstart",
+        "ed"
+      ],
+      [
+        "Ġstart",
+        "ing"
+      ],
+      [
+        "Ġstart",
+        "led"
+      ],
+      [
+        "ĠGood",
+        "bye"
+      ],
+      [
+        "li",
+        "ke"
+      ],
+      [
+        "li",
+        "vin"
+      ],
+      [
+        "li",
+        "quor"
+      ],
+      [
+        "pl",
+        "ace"
+      ],
+      [
+        "pl",
+        "oyees"
+      ],
+      [
+        "Ġid",
+        "iot"
+      ],
+      [
+        "Ġad",
+        "mit"
+      ],
+      [
+        "ĠIs",
+        "land"
+      ],
+      [
+        "ons",
+        "ib"
+      ],
+      [
+        "Ġye",
+        "ar"
+      ],
+      [
+        "Ġbur",
+        "nt"
+      ],
+      [
+        "Ġbur",
+        "gers"
+      ],
+      [
+        "Ġbur",
+        "ned"
+      ],
+      [
+        "Ġbur",
+        "den"
+      ],
+      [
+        "Ġmind",
+        "less"
+      ],
+      [
+        "Ġgu",
+        "est"
+      ],
+      [
+        "Ġgar",
+        "den"
+      ],
+      [
+        "Ġfell",
+        "a"
+      ],
+      [
+        "Ġfell",
+        "atio"
+      ],
+      [
+        "Ġcl",
+        "it"
+      ],
+      [
+        "Ġcl",
+        "ock"
+      ],
+      [
+        "Ġcl",
+        "oset"
+      ],
+      [
+        "ĠWhere",
+        "ver"
+      ],
+      [
+        "Ġpo",
+        "or"
+      ],
+      [
+        "ĠYour",
+        "s"
+      ],
+      [
+        "Ġret",
+        "ro"
+      ],
+      [
+        "Ġret",
+        "ort"
+      ],
+      [
+        "Ġret",
+        "iring"
+      ],
+      [
+        "Ġhands",
+        "ome"
+      ],
+      [
+        "ĠUn",
+        "less"
+      ],
+      [
+        "ĠUn",
+        "comfortable"
+      ],
+      [
+        "ĠUn",
+        "fortunate"
+      ],
+      [
+        "Ġbring",
+        "in"
+      ],
+      [
+        "Ġbring",
+        "ing"
+      ],
+      [
+        "ĠQu",
+        "ack"
+      ],
+      [
+        "ĠQu",
+        "ickly"
+      ],
+      [
+        "ĠCheese",
+        "burgers"
+      ],
+      [
+        "Ġtomato",
+        "es"
+      ],
+      [
+        "Ġbelie",
+        "ved"
+      ],
+      [
+        "ey",
+        "ball"
+      ],
+      [
+        "ped",
+        "iment"
+      ],
+      [
+        "Ġim",
+        "med"
+      ],
+      [
+        "Ġim",
+        "becile"
+      ],
+      [
+        "Ġim",
+        "pediment"
+      ],
+      [
+        "Ġte",
+        "am"
+      ],
+      [
+        "Ġte",
+        "xt"
+      ],
+      [
+        "Ġte",
+        "chniqu"
+      ],
+      [
+        "Ġab",
+        "use"
+      ],
+      [
+        "Ġab",
+        "usive"
+      ],
+      [
+        "Ġact",
+        "ress"
+      ],
+      [
+        "Ġact",
+        "ually"
+      ],
+      [
+        "Ġsleep",
+        "in"
+      ],
+      [
+        "ond",
+        "o"
+      ],
+      [
+        "Ġbed",
+        "spread"
+      ],
+      [
+        "Ġbull",
+        "shit"
+      ],
+      [
+        "Ġdri",
+        "ed"
+      ],
+      [
+        "Ġdri",
+        "ving"
+      ],
+      [
+        "Ġgir",
+        "lfriend"
+      ],
+      [
+        "Ġown",
+        "er"
+      ],
+      [
+        "Ġown",
+        "ed"
+      ],
+      [
+        "Ġpick",
+        "in"
+      ],
+      [
+        "Ġpick",
+        "ed"
+      ],
+      [
+        "ard",
+        "s"
+      ],
+      [
+        "Ġhu",
+        "ge"
+      ],
+      [
+        "ĠAn",
+        "wan"
+      ],
+      [
+        "ĠAn",
+        "swer"
+      ],
+      [
+        "ĠAn",
+        "geles"
+      ],
+      [
+        "amp",
+        "les"
+      ],
+      [
+        "Ġstick",
+        "s"
+      ],
+      [
+        "ign",
+        "ers"
+      ],
+      [
+        "ign",
+        "ated"
+      ],
+      [
+        "ĠRock",
+        "amora"
+      ],
+      [
+        "Ġworld",
+        "fam"
+      ],
+      [
+        "ĠUh",
+        "hh"
+      ],
+      [
+        "Ġjob",
+        "s"
+      ],
+      [
+        "Ġlaugh",
+        "s"
+      ],
+      [
+        "Ġlaugh",
+        "in"
+      ],
+      [
+        "Ġ2",
+        "2"
+      ],
+      [
+        "Ġen",
+        "cl"
+      ],
+      [
+        "Ġen",
+        "gag"
+      ],
+      [
+        "Ġtou",
+        "ched"
+      ],
+      [
+        "Ġtak",
+        "ing"
+      ],
+      [
+        "Ġsound",
+        "s"
+      ],
+      [
+        "Ġgl",
+        "ad"
+      ],
+      [
+        "Ġgl",
+        "ance"
+      ],
+      [
+        "Ġcare",
+        "s"
+      ],
+      [
+        "Ġper",
+        "cent"
+      ],
+      [
+        "Ġper",
+        "man"
+      ],
+      [
+        "Ġper",
+        "fect"
+      ],
+      [
+        "Ġper",
+        "iod"
+      ],
+      [
+        "Ġper",
+        "miss"
+      ],
+      [
+        "Ġper",
+        "formers"
+      ],
+      [
+        "Ġpri",
+        "ce"
+      ],
+      [
+        "Ġpri",
+        "ces"
+      ],
+      [
+        "Ġhurt",
+        "s"
+      ],
+      [
+        "Ġear",
+        "ly"
+      ],
+      [
+        "ĠMay",
+        "onna"
+      ],
+      [
+        "ĠMay",
+        "nard"
+      ],
+      [
+        "ĠAny",
+        "body"
+      ],
+      [
+        "ĠAny",
+        "way"
+      ],
+      [
+        "ĠAny",
+        "thing"
+      ],
+      [
+        "ĠBe",
+        "ating"
+      ],
+      [
+        "ĠSh",
+        "ow"
+      ],
+      [
+        "Ġstra",
+        "w"
+      ],
+      [
+        "ĠGot",
+        "ta"
+      ],
+      [
+        "Ġatt",
+        "ack"
+      ],
+      [
+        "Ġshepherd",
+        "ed"
+      ],
+      [
+        "Ġword",
+        "s"
+      ],
+      [
+        "Ġblood",
+        "iest"
+      ],
+      [
+        "ĠEx",
+        "pect"
+      ],
+      [
+        "ĠEx",
+        "ec"
+      ],
+      [
+        "ĠEx",
+        "cuse"
+      ],
+      [
+        "ĠEx",
+        "cell"
+      ],
+      [
+        "ĠEx",
+        "actly"
+      ],
+      [
+        "ĠEx",
+        "amples"
+      ],
+      [
+        "Ġquest",
+        "ions"
+      ],
+      [
+        "Ġchill",
+        "y"
+      ],
+      [
+        "cha",
+        "sed"
+      ],
+      [
+        "com",
+        "es"
+      ],
+      [
+        "Ġes",
+        "press"
+      ],
+      [
+        "Ġill",
+        "egal"
+      ],
+      [
+        "Ġra",
+        "re"
+      ],
+      [
+        "Ġra",
+        "id"
+      ],
+      [
+        "Ġra",
+        "ised"
+      ],
+      [
+        "Ġtw",
+        "ice"
+      ],
+      [
+        "Ġsc",
+        "ore"
+      ],
+      [
+        "Ġsc",
+        "our"
+      ],
+      [
+        "Ġsc",
+        "ary"
+      ],
+      [
+        "Ġsc",
+        "amps"
+      ],
+      [
+        "Ġsc",
+        "oop"
+      ],
+      [
+        "Ġsl",
+        "ope"
+      ],
+      [
+        "Ġsy",
+        "mp"
+      ],
+      [
+        "Ġsy",
+        "rup"
+      ],
+      [
+        "Ġser",
+        "vin"
+      ],
+      [
+        "ition",
+        "al"
+      ],
+      [
+        "Ġbum",
+        "s"
+      ],
+      [
+        "Ġbox",
+        "er"
+      ],
+      [
+        "Ġdou",
+        "ble"
+      ],
+      [
+        "Ġdis",
+        "co"
+      ],
+      [
+        "Ġdis",
+        "cus"
+      ],
+      [
+        "Ġdis",
+        "pos"
+      ],
+      [
+        "Ġdis",
+        "regar"
+      ],
+      [
+        "Ġdis",
+        "respect"
+      ],
+      [
+        "Ġdark",
+        "er"
+      ],
+      [
+        "Ġdream",
+        "s"
+      ],
+      [
+        "Ġfreak",
+        "in"
+      ],
+      [
+        "Ġfreak",
+        "ed"
+      ],
+      [
+        "Ġcr",
+        "isp"
+      ],
+      [
+        "Ġcr",
+        "acked"
+      ],
+      [
+        "Ġcho",
+        "ice"
+      ],
+      [
+        "Ġcho",
+        "ps"
+      ],
+      [
+        "Ġchan",
+        "ce"
+      ],
+      [
+        "Ġchan",
+        "ge"
+      ],
+      [
+        "Ġchan",
+        "ces"
+      ],
+      [
+        "Ġlay",
+        "ing"
+      ],
+      [
+        "Ġpart",
+        "s"
+      ],
+      [
+        "Ġpart",
+        "ners"
+      ],
+      [
+        "Ġinter",
+        "com"
+      ],
+      [
+        "Ġinter",
+        "ior"
+      ],
+      [
+        "Ġinter",
+        "ru"
+      ],
+      [
+        "Ġbeg",
+        "un"
+      ],
+      [
+        "Ġhang",
+        "in"
+      ],
+      [
+        "ĠBur",
+        "bank"
+      ],
+      [
+        "ĠSp",
+        "oken"
+      ],
+      [
+        "Ġstay",
+        "ed"
+      ],
+      [
+        "Ġreg",
+        "ular"
+      ],
+      [
+        "ĠCh",
+        "ina"
+      ],
+      [
+        "ĠFl",
+        "ock"
+      ],
+      [
+        "ĠFl",
+        "orid"
+      ],
+      [
+        "tain",
+        "s"
+      ],
+      [
+        "ĠRa",
+        "ven"
+      ],
+      [
+        "ĠEvery",
+        "thing"
+      ],
+      [
+        "ĠKn",
+        "ock"
+      ],
+      [
+        "ĠKn",
+        "ives"
+      ],
+      [
+        "ĠKn",
+        "ucklehead"
+      ],
+      [
+        "Ġcount",
+        "in"
+      ],
+      [
+        "Ġjok",
+        "in"
+      ],
+      [
+        "Ġjok",
+        "ing"
+      ],
+      [
+        "Ġchick",
+        "s"
+      ],
+      [
+        "Ġtouch",
+        "in"
+      ],
+      [
+        "Ġtouch",
+        "ing"
+      ],
+      [
+        "Ġquestion",
+        "ed"
+      ],
+      [
+        "ib",
+        "ility"
+      ],
+      [
+        "man",
+        "y"
+      ],
+      [
+        "Ġ1",
+        "00"
+      ],
+      [
+        "Ġ1",
+        "974"
+      ],
+      [
+        "Ġz",
+        "illion"
+      ],
+      [
+        "Ġz",
+        "ombies"
+      ],
+      [
+        "head",
+        "s"
+      ],
+      [
+        "Ġac",
+        "cept"
+      ],
+      [
+        "Ġac",
+        "centuate"
+      ],
+      [
+        "Ġwin",
+        "ner"
+      ],
+      [
+        "Ġsk",
+        "ills"
+      ],
+      [
+        "Ġsen",
+        "su"
+      ],
+      [
+        "Ġsen",
+        "sible"
+      ],
+      [
+        "Ġsil",
+        "ver"
+      ],
+      [
+        "Ġsil",
+        "ences"
+      ],
+      [
+        "Ġsign",
+        "ificant"
+      ],
+      [
+        "Ġsix",
+        "ty"
+      ],
+      [
+        "Ġsix",
+        "teen"
+      ],
+      [
+        "Ġbes",
+        "ide"
+      ],
+      [
+        "Ġmot",
+        "ion"
+      ],
+      [
+        "Ġmat",
+        "ch"
+      ],
+      [
+        "Ġmat",
+        "ches"
+      ],
+      [
+        "Ġmark",
+        "et"
+      ],
+      [
+        "Ġdes",
+        "ignated"
+      ],
+      [
+        "Ġfore",
+        "igners"
+      ],
+      [
+        "Ġche",
+        "w"
+      ],
+      [
+        "Ġche",
+        "ese"
+      ],
+      [
+        "Ġcamp",
+        "fire"
+      ],
+      [
+        "Ġpos",
+        "itive"
+      ],
+      [
+        "Ġhero",
+        "in"
+      ],
+      [
+        "ĠTr",
+        "uck"
+      ],
+      [
+        "ĠTr",
+        "ust"
+      ],
+      [
+        "Ġhid",
+        "in"
+      ],
+      [
+        "Ġmemor",
+        "y"
+      ],
+      [
+        "ĠHoll",
+        "and"
+      ],
+      [
+        "Ġwear",
+        "in"
+      ],
+      [
+        "Ġwash",
+        "in"
+      ],
+      [
+        "Ġstri",
+        "ppin"
+      ],
+      [
+        "Ġres",
+        "pect"
+      ],
+      [
+        "Ġres",
+        "idence"
+      ],
+      [
+        "Ġread",
+        "er"
+      ],
+      [
+        "Ġforg",
+        "ot"
+      ],
+      [
+        "Ġforg",
+        "ive"
+      ],
+      [
+        "Ġforg",
+        "ittin"
+      ],
+      [
+        "Ġforg",
+        "iven"
+      ],
+      [
+        "ĠRed",
+        "line"
+      ],
+      [
+        "ĠRed",
+        "ondo"
+      ],
+      [
+        "Ġring",
+        "ing"
+      ],
+      [
+        "Ġchar",
+        "min"
+      ],
+      [
+        "Ġdifferen",
+        "ces"
+      ],
+      [
+        "Ġpoint",
+        "ed"
+      ],
+      [
+        "Ġtele",
+        "vis"
+      ],
+      [
+        "Ġmoment",
+        "s"
+      ],
+      [
+        "Ġserious",
+        "ly"
+      ],
+      [
+        "ai",
+        "ian"
+      ],
+      [
+        "cl",
+        "ock"
+      ],
+      [
+        "cl",
+        "oud"
+      ],
+      [
+        "of",
+        "a"
+      ],
+      [
+        "vill",
+        "ian"
+      ],
+      [
+        "Ġve",
+        "hic"
+      ],
+      [
+        "Ġri",
+        "b"
+      ],
+      [
+        "Ġri",
+        "ch"
+      ],
+      [
+        "Ġri",
+        "ce"
+      ],
+      [
+        "Ġtri",
+        "ppin"
+      ],
+      [
+        "Ġar",
+        "rive"
+      ],
+      [
+        "Ġyell",
+        "a"
+      ],
+      [
+        "Ġbas",
+        "ically"
+      ],
+      [
+        "Ġbro",
+        "ke"
+      ],
+      [
+        "Ġbro",
+        "ad"
+      ],
+      [
+        "Ġbro",
+        "ken"
+      ],
+      [
+        "Ġbir",
+        "ds"
+      ],
+      [
+        "Ġmess",
+        "y"
+      ],
+      [
+        "Ġmouth",
+        "s"
+      ],
+      [
+        "Ġdy",
+        "sent"
+      ],
+      [
+        "Ġdin",
+        "ers"
+      ],
+      [
+        "Ġgen",
+        "erations"
+      ],
+      [
+        "Ġgra",
+        "b"
+      ],
+      [
+        "Ġgra",
+        "veyard"
+      ],
+      [
+        "Ġgra",
+        "cias"
+      ],
+      [
+        "Ġgang",
+        "sta"
+      ],
+      [
+        "Ġfl",
+        "at"
+      ],
+      [
+        "Ġfl",
+        "ies"
+      ],
+      [
+        "Ġfl",
+        "avor"
+      ],
+      [
+        "Ġfing",
+        "er"
+      ],
+      [
+        "Ġfox",
+        "y"
+      ],
+      [
+        "Ġfound",
+        "ation"
+      ],
+      [
+        "Ġfinish",
+        "ing"
+      ],
+      [
+        "erv",
+        "ation"
+      ],
+      [
+        "Ġcas",
+        "h"
+      ],
+      [
+        "Ġcro",
+        "aks"
+      ],
+      [
+        "Ġcir",
+        "cle"
+      ],
+      [
+        "Ġcap",
+        "tu"
+      ],
+      [
+        "Ġcorrect",
+        "ly"
+      ],
+      [
+        "Ġcertain",
+        "ly"
+      ],
+      [
+        "Ġtoss",
+        "ed"
+      ],
+      [
+        "ĠWar",
+        "mer"
+      ],
+      [
+        "ĠWill",
+        "is"
+      ],
+      [
+        "Ġnam",
+        "ed"
+      ],
+      [
+        "Ġpa",
+        "ir"
+      ],
+      [
+        "Ġpig",
+        "s"
+      ],
+      [
+        "Ġpack",
+        "s"
+      ],
+      [
+        "Ġpunch",
+        "y"
+      ],
+      [
+        "Ġpiss",
+        "ed"
+      ],
+      [
+        "Ġposs",
+        "ess"
+      ],
+      [
+        "Ġthrow",
+        "ing"
+      ],
+      [
+        "Ġinst",
+        "inct"
+      ],
+      [
+        "Ġbec",
+        "ame"
+      ],
+      [
+        "Ġhour",
+        "s"
+      ],
+      [
+        "Ġeye",
+        "brow"
+      ],
+      [
+        "ĠMer",
+        "de"
+      ],
+      [
+        "Ġshop",
+        "pin"
+      ],
+      [
+        "Ġkick",
+        "s"
+      ],
+      [
+        "ĠSe",
+        "ven"
+      ],
+      [
+        "ĠSe",
+        "arch"
+      ],
+      [
+        "ĠSe",
+        "agull"
+      ],
+      [
+        "ĠSom",
+        "eday"
+      ],
+      [
+        "Ġstab",
+        "bing"
+      ],
+      [
+        "Ġresta",
+        "urant"
+      ],
+      [
+        "ĠJew",
+        "s"
+      ],
+      [
+        "Ġmanag",
+        "ers"
+      ],
+      [
+        "ĠFonz",
+        "ies"
+      ],
+      [
+        "ĠOD",
+        "in"
+      ],
+      [
+        "ĠOn",
+        "ly"
+      ],
+      [
+        "ĠRes",
+        "taurants"
+      ],
+      [
+        "Ġplay",
+        "ed"
+      ],
+      [
+        "Ġexec",
+        "ution"
+      ],
+      [
+        "Ġinterest",
+        "ed"
+      ],
+      [
+        "Ġinterest",
+        "ing"
+      ],
+      [
+        "ĠUu",
+        "ummmm"
+      ],
+      [
+        "ĠUu",
+        "uu"
+      ],
+      [
+        "ĠUu",
+        "ccch"
+      ],
+      [
+        "Ġrisk",
+        "y"
+      ],
+      [
+        "ump",
+        "y"
+      ],
+      [
+        "Ġcomp",
+        "rend"
+      ],
+      [
+        "Ġlead",
+        "er"
+      ],
+      [
+        "Ġcold",
+        "bl"
+      ],
+      [
+        "Ġcollect",
+        "ed"
+      ],
+      [
+        "Ġcoun",
+        "selor"
+      ],
+      [
+        "Ġprotect",
+        "ing"
+      ],
+      [
+        "Ġspl",
+        "atter"
+      ],
+      [
+        "Ġspec",
+        "imens"
+      ],
+      [
+        "Ġcontin",
+        "ued"
+      ],
+      [
+        "Ġadventure",
+        "s"
+      ],
+      [
+        "Ġdrive",
+        "way"
+      ],
+      [
+        "ĠMonro",
+        "es"
+      ],
+      [
+        "Ġdeliver",
+        "ing"
+      ],
+      [
+        "ON",
+        "E"
+      ],
+      [
+        "do",
+        "ings"
+      ],
+      [
+        "gl",
+        "ers"
+      ],
+      [
+        "led",
+        "ge"
+      ],
+      [
+        "now",
+        "ledge"
+      ],
+      [
+        "sh",
+        "ort"
+      ],
+      [
+        "sh",
+        "irt"
+      ],
+      [
+        "Ġ8",
+        "18"
+      ],
+      [
+        "Ġtick",
+        "ing"
+      ],
+      [
+        "Ġtick",
+        "le"
+      ],
+      [
+        "Ġtend",
+        "er"
+      ],
+      [
+        "Ġwet",
+        "back"
+      ],
+      [
+        "Ġsw",
+        "ine"
+      ],
+      [
+        "Ġsw",
+        "itch"
+      ],
+      [
+        "Ġsat",
+        "isfied"
+      ],
+      [
+        "Ġsell",
+        "er"
+      ],
+      [
+        "Ġbo",
+        "il"
+      ],
+      [
+        "Ġbo",
+        "ards"
+      ],
+      [
+        "Ġbu",
+        "ilt"
+      ],
+      [
+        "Ġbu",
+        "bble"
+      ],
+      [
+        "Ġble",
+        "u"
+      ],
+      [
+        "Ġble",
+        "w"
+      ],
+      [
+        "Ġbal",
+        "d"
+      ],
+      [
+        "Ġbal",
+        "cony"
+      ],
+      [
+        "Ġmiss",
+        "ed"
+      ],
+      [
+        "Ġdry",
+        "in"
+      ],
+      [
+        "Ġdick",
+        "s"
+      ],
+      [
+        "Ġdick",
+        "less"
+      ],
+      [
+        "Ġgr",
+        "asped"
+      ],
+      [
+        "Ġgr",
+        "umpy"
+      ],
+      [
+        "Ġfut",
+        "ure"
+      ],
+      [
+        "Ġfut",
+        "ility"
+      ],
+      [
+        "Ġfam",
+        "ily"
+      ],
+      [
+        "Ġfam",
+        "iliar"
+      ],
+      [
+        "Ġfix",
+        "ed"
+      ],
+      [
+        "Ġfire",
+        "place"
+      ],
+      [
+        "Ġcon",
+        "fis"
+      ],
+      [
+        "Ġcon",
+        "centration"
+      ],
+      [
+        "Ġcor",
+        "ny"
+      ],
+      [
+        "Ġcor",
+        "pse"
+      ],
+      [
+        "Ġcow",
+        "boy"
+      ],
+      [
+        "Ġcow",
+        "gir"
+      ],
+      [
+        "Ġcorn",
+        "erst"
+      ],
+      [
+        "Ġodd",
+        "s"
+      ],
+      [
+        "Ġla",
+        "wn"
+      ],
+      [
+        "Ġla",
+        "zy"
+      ],
+      [
+        "Ġni",
+        "pples"
+      ],
+      [
+        "Ġni",
+        "pple"
+      ],
+      [
+        "Ġnut",
+        "rit"
+      ],
+      [
+        "Ġph",
+        "otogra"
+      ],
+      [
+        "Ġph",
+        "ilos"
+      ],
+      [
+        "Ġpar",
+        "alyze"
+      ],
+      [
+        "Ġpar",
+        "amount"
+      ],
+      [
+        "Ġpen",
+        "cil"
+      ],
+      [
+        "Ġpal",
+        "ms"
+      ],
+      [
+        "Ġpal",
+        "ooka"
+      ],
+      [
+        "Ġpur",
+        "se"
+      ],
+      [
+        "Ġpur",
+        "chased"
+      ],
+      [
+        "Ġpull",
+        "ing"
+      ],
+      [
+        "Ġpres",
+        "ent"
+      ],
+      [
+        "Ġpres",
+        "ervation"
+      ],
+      [
+        "Ġinfor",
+        "med"
+      ],
+      [
+        "Ġinfor",
+        "mation"
+      ],
+      [
+        "Ġinvol",
+        "ve"
+      ],
+      [
+        "Ġinvol",
+        "ved"
+      ],
+      [
+        "ĠTow",
+        "el"
+      ],
+      [
+        "ĠTry",
+        "ing"
+      ],
+      [
+        "Ġhun",
+        "k"
+      ],
+      [
+        "Ġhun",
+        "gry"
+      ],
+      [
+        "Ġholy",
+        "ies"
+      ],
+      [
+        "Ġholy",
+        "iest"
+      ],
+      [
+        "Ġhigh",
+        "s"
+      ],
+      [
+        "Ġem",
+        "bar"
+      ],
+      [
+        "Ġem",
+        "ployees"
+      ],
+      [
+        "Ġeff",
+        "ect"
+      ],
+      [
+        "Ġeff",
+        "ort"
+      ],
+      [
+        "ĠMiss",
+        "us"
+      ],
+      [
+        "ĠAl",
+        "so"
+      ],
+      [
+        "ĠAl",
+        "most"
+      ],
+      [
+        "ĠBea",
+        "ch"
+      ],
+      [
+        "ĠBea",
+        "utiful"
+      ],
+      [
+        "ĠBoy",
+        "s"
+      ],
+      [
+        "ĠNeg",
+        "ro"
+      ],
+      [
+        "ĠNeg",
+        "ative"
+      ],
+      [
+        "Ġwee",
+        "k"
+      ],
+      [
+        "Ġwee",
+        "ks"
+      ],
+      [
+        "Ġweir",
+        "do"
+      ],
+      [
+        "Ġweir",
+        "dest"
+      ],
+      [
+        "Ġlight",
+        "s"
+      ],
+      [
+        "Ġju",
+        "ry"
+      ],
+      [
+        "Ġju",
+        "ice"
+      ],
+      [
+        "Ġjud",
+        "ge"
+      ],
+      [
+        "Ġjud",
+        "ging"
+      ],
+      [
+        "Ġreact",
+        "ion"
+      ],
+      [
+        "ĠCho",
+        "ice"
+      ],
+      [
+        "ĠCho",
+        "co"
+      ],
+      [
+        "ĠCount",
+        "ing"
+      ],
+      [
+        "ĠGer",
+        "mans"
+      ],
+      [
+        "ĠGer",
+        "many"
+      ],
+      [
+        "ĠOoo",
+        "ohh"
+      ],
+      [
+        "ĠOoo",
+        "ooooh"
+      ],
+      [
+        "Ġbutter",
+        "in"
+      ],
+      [
+        "Ġbutter",
+        "milk"
+      ],
+      [
+        "ĠPr",
+        "ide"
+      ],
+      [
+        "ĠPr",
+        "omise"
+      ],
+      [
+        "ĠRe",
+        "ally"
+      ],
+      [
+        "ĠRe",
+        "ady"
+      ],
+      [
+        "Ġdec",
+        "ide"
+      ],
+      [
+        "Ġdec",
+        "ided"
+      ],
+      [
+        "Ġassho",
+        "le"
+      ],
+      [
+        "Ġassho",
+        "les"
+      ],
+      [
+        "Ġsub",
+        "ject"
+      ],
+      [
+        "Ġsub",
+        "terfu"
+      ],
+      [
+        "ĠEl",
+        "mo"
+      ],
+      [
+        "ĠEl",
+        "vis"
+      ],
+      [
+        "Ġsaus",
+        "age"
+      ],
+      [
+        "Ġsaus",
+        "ages"
+      ],
+      [
+        "Ġprod",
+        "uct"
+      ],
+      [
+        "Ġprod",
+        "igy"
+      ],
+      [
+        "umb",
+        "ian"
+      ],
+      [
+        "Ġcomfor",
+        "ters"
+      ],
+      [
+        "Ġcomfor",
+        "tably"
+      ],
+      [
+        "Ġprinci",
+        "ple"
+      ],
+      [
+        "Ġprinci",
+        "pal"
+      ],
+      [
+        "Ġkey",
+        "s"
+      ],
+      [
+        "Ġkey",
+        "ed"
+      ],
+      [
+        "Ġthank",
+        "ed"
+      ],
+      [
+        "Ġvisit",
+        "or"
+      ],
+      [
+        "Ġtrans",
+        "port"
+      ],
+      [
+        "Ġtrans",
+        "itional"
+      ],
+      [
+        "Ġrealiz",
+        "e"
+      ],
+      [
+        "Ġrealiz",
+        "ation"
+      ],
+      [
+        "Ġcleans",
+        "ers"
+      ],
+      [
+        "Ġpriv",
+        "ate"
+      ],
+      [
+        "Ġpriv",
+        "ile"
+      ],
+      [
+        "Ġillustr",
+        "ate"
+      ],
+      [
+        "Ġillustr",
+        "ating"
+      ],
+      [
+        "Ġslight",
+        "ly"
+      ],
+      [
+        "Ġacro",
+        "ss"
+      ],
+      [
+        "Ġacro",
+        "bat"
+      ],
+      [
+        "Ġbottom",
+        "s"
+      ],
+      [
+        "Ġcheck",
+        "ing"
+      ],
+      [
+        "ĠBlood",
+        "y"
+      ],
+      [
+        "Ġresp",
+        "onse"
+      ],
+      [
+        "Ġresp",
+        "onsib"
+      ],
+      [
+        "Ġexperien",
+        "ce"
+      ],
+      [
+        "Ġexperien",
+        "ced"
+      ],
+      [
+        "Ġimposs",
+        "ible"
+      ],
+      [
+        "Ġimposs",
+        "ibility"
+      ],
+      [
+        "Ġimport",
+        "ant"
+      ],
+      [
+        "Ġimport",
+        "ance"
+      ],
+      [
+        "Ġcross",
+        "in"
+      ],
+      [
+        "Ġloyal",
+        "ty"
+      ],
+      [
+        "Ġexplos",
+        "ive"
+      ],
+      [
+        "Ġexplos",
+        "ions"
+      ],
+      [
+        "Ġunload",
+        "s"
+      ],
+      [
+        "35",
+        "7"
+      ],
+      [
+        "AR",
+        "ONE"
+      ],
+      [
+        "Bed",
+        "side"
+      ],
+      [
+        "Bat",
+        "on"
+      ],
+      [
+        "CO",
+        "PS"
+      ],
+      [
+        "Emp",
+        "ty"
+      ],
+      [
+        "FL",
+        "Y"
+      ],
+      [
+        "FO",
+        "X"
+      ],
+      [
+        "Good",
+        "night"
+      ],
+      [
+        "GUN",
+        "S"
+      ],
+      [
+        "Hoy",
+        "le"
+      ],
+      [
+        "KUN",
+        "G"
+      ],
+      [
+        "Luck",
+        "y"
+      ],
+      [
+        "Mar",
+        "vin"
+      ],
+      [
+        "PER",
+        "FLY"
+      ],
+      [
+        "SU",
+        "PERFLY"
+      ],
+      [
+        "arett",
+        "es"
+      ],
+      [
+        "but",
+        "t"
+      ],
+      [
+        "fie",
+        "ld"
+      ],
+      [
+        "full",
+        "y"
+      ],
+      [
+        "gumm",
+        "ers"
+      ],
+      [
+        "iate",
+        "ly"
+      ],
+      [
+        "lay",
+        "in"
+      ],
+      [
+        "pop",
+        "pin"
+      ],
+      [
+        "rass",
+        "ed"
+      ],
+      [
+        "spe",
+        "ak"
+      ],
+      [
+        "tw",
+        "enty"
+      ],
+      [
+        "war",
+        "m"
+      ],
+      [
+        "Ġought",
+        "a"
+      ],
+      [
+        "Ġoun",
+        "ce"
+      ],
+      [
+        "Ġ700",
+        "0"
+      ],
+      [
+        "Ġtack",
+        "s"
+      ],
+      [
+        "Ġtain",
+        "ted"
+      ],
+      [
+        "oufl",
+        "age"
+      ],
+      [
+        "Ġack",
+        "nowledge"
+      ],
+      [
+        "Ġwol",
+        "ves"
+      ],
+      [
+        "Ġwhad",
+        "da"
+      ],
+      [
+        "Ġwhit",
+        "es"
+      ],
+      [
+        "Ġshat",
+        "ter"
+      ],
+      [
+        "Ġsing",
+        "le"
+      ],
+      [
+        "Ġsuck",
+        "in"
+      ],
+      [
+        "Ġsweet",
+        "ie"
+      ],
+      [
+        "Ġbor",
+        "ing"
+      ],
+      [
+        "Ġbow",
+        "l"
+      ],
+      [
+        "Ġbat",
+        "tle"
+      ],
+      [
+        "Ġbri",
+        "m"
+      ],
+      [
+        "Ġbod",
+        "ies"
+      ],
+      [
+        "Ġbother",
+        "ing"
+      ],
+      [
+        "Ġbour",
+        "bon"
+      ],
+      [
+        "Ġbark",
+        "in"
+      ],
+      [
+        "Ġbreat",
+        "he"
+      ],
+      [
+        "Ġmer",
+        "it"
+      ],
+      [
+        "Ġmor",
+        "al"
+      ],
+      [
+        "Ġmar",
+        "riage"
+      ],
+      [
+        "Ġmid",
+        "st"
+      ],
+      [
+        "Ġmam",
+        "a"
+      ],
+      [
+        "Ġmak",
+        "in"
+      ],
+      [
+        "Ġmuse",
+        "um"
+      ],
+      [
+        "Ġmain",
+        "tain"
+      ],
+      [
+        "Ġmap",
+        "le"
+      ],
+      [
+        "Ġmush",
+        "room"
+      ],
+      [
+        "Ġmonth",
+        "s"
+      ],
+      [
+        "Ġtheat",
+        "re"
+      ],
+      [
+        "Ġtheolo",
+        "gical"
+      ],
+      [
+        "Ġdet",
+        "ail"
+      ],
+      [
+        "Ġdom",
+        "esticated"
+      ],
+      [
+        "Ġdut",
+        "y"
+      ],
+      [
+        "Ġdro",
+        "ve"
+      ],
+      [
+        "Ġdem",
+        "olition"
+      ],
+      [
+        "Ġdea",
+        "f"
+      ],
+      [
+        "Ġdra",
+        "wer"
+      ],
+      [
+        "Ġdren",
+        "ched"
+      ],
+      [
+        "Ġdaught",
+        "er"
+      ],
+      [
+        "Ġdork",
+        "y"
+      ],
+      [
+        "Ġgor",
+        "illa"
+      ],
+      [
+        "Ġgim",
+        "mick"
+      ],
+      [
+        "Ġgig",
+        "gle"
+      ],
+      [
+        "Ġglo",
+        "ves"
+      ],
+      [
+        "Ġfri",
+        "es"
+      ],
+      [
+        "Ġfill",
+        "ed"
+      ],
+      [
+        "Ġfem",
+        "ale"
+      ],
+      [
+        "Ġfir",
+        "mly"
+      ],
+      [
+        "Ġfright",
+        "ening"
+      ],
+      [
+        "Ġfac",
+        "ing"
+      ],
+      [
+        "Ġfren",
+        "zy"
+      ],
+      [
+        "Ġfree",
+        "ze"
+      ],
+      [
+        "Ġfoll",
+        "ow"
+      ],
+      [
+        "Ġfles",
+        "h"
+      ],
+      [
+        "Ġfunn",
+        "iest"
+      ],
+      [
+        "Ġfurn",
+        "ished"
+      ],
+      [
+        "Ġcet",
+        "a"
+      ],
+      [
+        "Ġcal",
+        "m"
+      ],
+      [
+        "Ġcam",
+        "ouflage"
+      ],
+      [
+        "Ġcig",
+        "arettes"
+      ],
+      [
+        "Ġcour",
+        "t"
+      ],
+      [
+        "Ġcol",
+        "a"
+      ],
+      [
+        "Ġcred",
+        "it"
+      ],
+      [
+        "Ġcav",
+        "alry"
+      ],
+      [
+        "Ġcrow",
+        "d"
+      ],
+      [
+        "Ġcaus",
+        "ing"
+      ],
+      [
+        "Ġocc",
+        "urren"
+      ],
+      [
+        "Ġoaf",
+        "ish"
+      ],
+      [
+        "Ġomel",
+        "et"
+      ],
+      [
+        "Ġtoast",
+        "ed"
+      ],
+      [
+        "Ġtobac",
+        "co"
+      ],
+      [
+        "Ġlat",
+        "er"
+      ],
+      [
+        "Ġlam",
+        "b"
+      ],
+      [
+        "Ġlem",
+        "on"
+      ],
+      [
+        "Ġlag",
+        "ging"
+      ],
+      [
+        "Ġlos",
+        "in"
+      ],
+      [
+        "Ġlone",
+        "ly"
+      ],
+      [
+        "Ġlac",
+        "ed"
+      ],
+      [
+        "Ġlue",
+        "go"
+      ],
+      [
+        "Ġlaw",
+        "yer"
+      ],
+      [
+        "ĠWind",
+        "ex"
+      ],
+      [
+        "ĠWalk",
+        "er"
+      ],
+      [
+        "ĠWait",
+        "resses"
+      ],
+      [
+        "Ġnat",
+        "ural"
+      ],
+      [
+        "Ġnim",
+        "rod"
+      ],
+      [
+        "Ġnurs",
+        "es"
+      ],
+      [
+        "Ġnuis",
+        "ance"
+      ],
+      [
+        "Ġpet",
+        "rified"
+      ],
+      [
+        "Ġprou",
+        "d"
+      ],
+      [
+        "Ġpul",
+        "se"
+      ],
+      [
+        "Ġpool",
+        "s"
+      ],
+      [
+        "Ġpain",
+        "ful"
+      ],
+      [
+        "Ġpap",
+        "er"
+      ],
+      [
+        "Ġpist",
+        "ol"
+      ],
+      [
+        "Ġpec",
+        "uliar"
+      ],
+      [
+        "Ġpuff",
+        "in"
+      ],
+      [
+        "Ġthro",
+        "at"
+      ],
+      [
+        "Ġthick",
+        "er"
+      ],
+      [
+        "Ġthreat",
+        "enin"
+      ],
+      [
+        "Ġinsign",
+        "ificant"
+      ],
+      [
+        "ĠTho",
+        "se"
+      ],
+      [
+        "ĠTaster",
+        "s"
+      ],
+      [
+        "ĠTahit",
+        "i"
+      ],
+      [
+        "ĠTues",
+        "day"
+      ],
+      [
+        "Ġbever",
+        "age"
+      ],
+      [
+        "Ġhom",
+        "es"
+      ],
+      [
+        "Ġhum",
+        "or"
+      ],
+      [
+        "Ġhip",
+        "s"
+      ],
+      [
+        "Ġhors",
+        "es"
+      ],
+      [
+        "Ġhyster",
+        "ical"
+      ],
+      [
+        "Ġmelt",
+        "ed"
+      ],
+      [
+        "Ġeld",
+        "ers"
+      ],
+      [
+        "Ġequ",
+        "ally"
+      ],
+      [
+        "Ġelem",
+        "ent"
+      ],
+      [
+        "Ġepis",
+        "ode"
+      ],
+      [
+        "ĠMad",
+        "onna"
+      ],
+      [
+        "ĠMam",
+        "ie"
+      ],
+      [
+        "ĠMag",
+        "num"
+      ],
+      [
+        "ĠMuch",
+        "o"
+      ],
+      [
+        "ĠMans",
+        "field"
+      ],
+      [
+        "ĠMoun",
+        "tains"
+      ],
+      [
+        "ĠMax",
+        "ie"
+      ],
+      [
+        "ĠMOT",
+        "ION"
+      ],
+      [
+        "ĠMaj",
+        "or"
+      ],
+      [
+        "ĠMedie",
+        "val"
+      ],
+      [
+        "ĠMalib",
+        "u"
+      ],
+      [
+        "ĠAct",
+        "ually"
+      ],
+      [
+        "ĠAcc",
+        "ording"
+      ],
+      [
+        "ĠAfric",
+        "an"
+      ],
+      [
+        "ĠBust",
+        "er"
+      ],
+      [
+        "ĠBank",
+        "s"
+      ],
+      [
+        "ĠBash",
+        "ful"
+      ],
+      [
+        "ĠBusboy",
+        "s"
+      ],
+      [
+        "Ġkun",
+        "g"
+      ],
+      [
+        "Ġketch",
+        "up"
+      ],
+      [
+        "ĠHur",
+        "ry"
+      ],
+      [
+        "ĠHart",
+        "z"
+      ],
+      [
+        "ĠHaw",
+        "aiian"
+      ],
+      [
+        "ĠHope",
+        "fully"
+      ],
+      [
+        "ĠNig",
+        "ger"
+      ],
+      [
+        "ĠNorm",
+        "ally"
+      ],
+      [
+        "ĠNAV",
+        "ARONE"
+      ],
+      [
+        "ĠSir",
+        "k"
+      ],
+      [
+        "ĠSho",
+        "ot"
+      ],
+      [
+        "ĠSac",
+        "re"
+      ],
+      [
+        "ĠSomet",
+        "hing"
+      ],
+      [
+        "ĠSound",
+        "s"
+      ],
+      [
+        "ĠSli",
+        "p"
+      ],
+      [
+        "ĠSaus",
+        "ages"
+      ],
+      [
+        "ĠScot",
+        "ty"
+      ],
+      [
+        "Ġstren",
+        "gth"
+      ],
+      [
+        "Ġsteal",
+        "in"
+      ],
+      [
+        "Ġstrag",
+        "glers"
+      ],
+      [
+        "ĠWhatsam",
+        "atter"
+      ],
+      [
+        "Ġansw",
+        "ers"
+      ],
+      [
+        "Ġunderest",
+        "imatin"
+      ],
+      [
+        "ĠDore",
+        "n"
+      ],
+      [
+        "ĠDod",
+        "ge"
+      ],
+      [
+        "ĠDur",
+        "wood"
+      ],
+      [
+        "ĠDough",
+        "boy"
+      ],
+      [
+        "ĠDougl",
+        "as"
+      ],
+      [
+        "Ġjoy",
+        "poppin"
+      ],
+      [
+        "Ġjang",
+        "ling"
+      ],
+      [
+        "Ġjail",
+        "house"
+      ],
+      [
+        "store",
+        "s"
+      ],
+      [
+        "Ġrequ",
+        "est"
+      ],
+      [
+        "Ġrepug",
+        "nant"
+      ],
+      [
+        "Ġoutfit",
+        "s"
+      ],
+      [
+        "ĠCop",
+        "s"
+      ],
+      [
+        "ĠCol",
+        "umbian"
+      ],
+      [
+        "ĠCap",
+        "t"
+      ],
+      [
+        "ĠClim",
+        "b"
+      ],
+      [
+        "ĠCoun",
+        "ty"
+      ],
+      [
+        "ĠChall",
+        "enge"
+      ],
+      [
+        "ĠCarib",
+        "bean"
+      ],
+      [
+        "ĠGra",
+        "ce"
+      ],
+      [
+        "ĠGrand",
+        "pa"
+      ],
+      [
+        "ĠFil",
+        "ters"
+      ],
+      [
+        "ĠFore",
+        "ver"
+      ],
+      [
+        "ĠFIV",
+        "E"
+      ],
+      [
+        "ĠFOR",
+        "CE"
+      ],
+      [
+        "Ġsevent",
+        "ies"
+      ],
+      [
+        "Ġsepar",
+        "ation"
+      ],
+      [
+        "ĠPos",
+        "itive"
+      ],
+      [
+        "ĠPac",
+        "ific"
+      ],
+      [
+        "ĠPeg",
+        "gy"
+      ],
+      [
+        "ĠPors",
+        "che"
+      ],
+      [
+        "ĠPICT",
+        "URE"
+      ],
+      [
+        "ĠLaw",
+        "s"
+      ],
+      [
+        "ĠRic",
+        "hard"
+      ],
+      [
+        "ĠRap",
+        "ist"
+      ],
+      [
+        "ĠRoll",
+        "in"
+      ],
+      [
+        "Ġdelic",
+        "ate"
+      ],
+      [
+        "Ġdevelop",
+        "ed"
+      ],
+      [
+        "Ġassoci",
+        "ates"
+      ],
+      [
+        "Ġplug",
+        "gin"
+      ],
+      [
+        "Ġsucc",
+        "essful"
+      ],
+      [
+        "Ġblond",
+        "e"
+      ],
+      [
+        "Ġblasphe",
+        "me"
+      ],
+      [
+        "Ġexcess",
+        "ive"
+      ],
+      [
+        "Ġexcit",
+        "ing"
+      ],
+      [
+        "ĠThurs",
+        "day"
+      ],
+      [
+        "ĠEuro",
+        "pe"
+      ],
+      [
+        "Ġqualif",
+        "ies"
+      ],
+      [
+        "Ġprogr",
+        "ams"
+      ],
+      [
+        "Ġpropri",
+        "etor"
+      ],
+      [
+        "Ġprosper",
+        "ous"
+      ],
+      [
+        "Ġintrigu",
+        "ing"
+      ],
+      [
+        "Ġration",
+        "ale"
+      ],
+      [
+        "Ġrud",
+        "e"
+      ],
+      [
+        "Ġoverreact",
+        "ed"
+      ],
+      [
+        "Ġdeadli",
+        "est"
+      ],
+      [
+        "Ġcompl",
+        "ete"
+      ],
+      [
+        "Ġgreenhous",
+        "es"
+      ],
+      [
+        "Ġpronun",
+        "ciation"
+      ],
+      [
+        "Ġagoniz",
+        "ing"
+      ],
+      [
+        "Ġvoll",
+        "eyball"
+      ],
+      [
+        "Ġvict",
+        "orious"
+      ],
+      [
+        "Ġvaude",
+        "villian"
+      ],
+      [
+        "Ġchamp",
+        "ion"
+      ],
+      [
+        "ĠStudi",
+        "os"
+      ],
+      [
+        "Ġunreal",
+        "istic"
+      ],
+      [
+        "Ġadmit",
+        "s"
+      ],
+      [
+        "ĠUnfortunate",
+        "ly"
+      ],
+      [
+        "Ġimmed",
+        "iately"
+      ],
+      [
+        "Ġtechniqu",
+        "e"
+      ],
+      [
+        "Ġbedspread",
+        "s"
+      ],
+      [
+        "Ġworldfam",
+        "ous"
+      ],
+      [
+        "Ġencl",
+        "osed"
+      ],
+      [
+        "Ġengag",
+        "ement"
+      ],
+      [
+        "Ġperman",
+        "ently"
+      ],
+      [
+        "Ġperfect",
+        "ly"
+      ],
+      [
+        "Ġpermiss",
+        "ion"
+      ],
+      [
+        "ĠMayonna",
+        "ise"
+      ],
+      [
+        "ĠExec",
+        "ute"
+      ],
+      [
+        "ĠExcell",
+        "ent"
+      ],
+      [
+        "Ġespress",
+        "o"
+      ],
+      [
+        "Ġslope",
+        "heads"
+      ],
+      [
+        "Ġsymp",
+        "athetic"
+      ],
+      [
+        "Ġdiscus",
+        "sion"
+      ],
+      [
+        "Ġdispos",
+        "ing"
+      ],
+      [
+        "Ġdisregar",
+        "d"
+      ],
+      [
+        "Ġinterru",
+        "pt"
+      ],
+      [
+        "Ġregular",
+        "ly"
+      ],
+      [
+        "ĠFlorid",
+        "a"
+      ],
+      [
+        "Ġaccept",
+        "ed"
+      ],
+      [
+        "Ġsensu",
+        "al"
+      ],
+      [
+        "Ġtelevis",
+        "ion"
+      ],
+      [
+        "Ġvehic",
+        "le"
+      ],
+      [
+        "Ġdysent",
+        "ery"
+      ],
+      [
+        "Ġcaptu",
+        "red"
+      ],
+      [
+        "ĠSearch",
+        "ing"
+      ],
+      [
+        "ĠSeagull",
+        "s"
+      ],
+      [
+        "ĠUuuu",
+        "ummmm"
+      ],
+      [
+        "Ġcomprend",
+        "e"
+      ],
+      [
+        "Ġcoldbl",
+        "ooded"
+      ],
+      [
+        "Ġconfis",
+        "cated"
+      ],
+      [
+        "Ġcowgir",
+        "l"
+      ],
+      [
+        "Ġcornerst",
+        "one"
+      ],
+      [
+        "Ġnutrit",
+        "ious"
+      ],
+      [
+        "Ġphotogra",
+        "phic"
+      ],
+      [
+        "Ġphilos",
+        "ophy"
+      ],
+      [
+        "Ġpencil",
+        "s"
+      ],
+      [
+        "Ġembar",
+        "rassed"
+      ],
+      [
+        "ĠOooohh",
+        "hh"
+      ],
+      [
+        "Ġsubterfu",
+        "ge"
+      ],
+      [
+        "Ġproduct",
+        "s"
+      ],
+      [
+        "Ġprincipal",
+        "s"
+      ],
+      [
+        "Ġprivile",
+        "ges"
+      ],
+      [
+        "Ġresponsib",
+        "ilities"
+      ],
+      [
+        "Ġoccurren",
+        "ce"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add script to train BPE tokenizer from dataset
- load pretrained tokenizer.json at startup
- test that tokenizer vocabulary covers basic characters and dataset words

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec00352608329a9a0ef979717df22