### PR TITLE
Fix core generation and monitoring utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+httpx
 uvicorn
 torch
 numpy


### PR DESCRIPTION
## Summary
- ensure httpx dependency is included
- handle models lacking advanced kwargs with a safe generation helper
- fix dataset watcher paths and register monitor shutdown
- return code execution results and improve reasoning loop step counting

## Testing
- `pytest -q`
- `flake8 indiana_core.py | head -n 20` *(fails: E302 expected 2 blank lines, found 1, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688f274f65988329a228da816a7f3468